### PR TITLE
Update High Level Prototypes and add Makefile

### DIFF
--- a/High Level Prototypes/Makefile
+++ b/High Level Prototypes/Makefile
@@ -1,0 +1,11 @@
+TARGETS = hex0 hex1 hex2 kaem-minimal
+
+all: $(TARGETS)
+
+clean:
+	rm $(TARGETS)
+
+.PHONY: all clean
+
+%: %.c ../M2libc/bootstrappable.c
+	$(CC) $^ -o $@

--- a/High Level Prototypes/hex2.c
+++ b/High Level Prototypes/hex2.c
@@ -34,7 +34,6 @@ char* numerate_number(int a);
 int in_set(int c, char* s);
 int match(char* a, char* b);
 int numerate_string(char *a);
-void file_print(char* s, FILE* f);
 void require(int bool, char* error);
 
 struct entry
@@ -116,9 +115,9 @@ unsigned GetTarget(char* c)
 			return i->target;
 		}
 	}
-	file_print("Target label ", stderr);
-	file_print(c, stderr);
-	file_print(" is not valid\n", stderr);
+	fputs("Target label ", stderr);
+	fputs(c, stderr);
+	fputs(" is not valid\n", stderr);
 	exit(EXIT_FAILURE);
 }
 

--- a/High Level Prototypes/kaem-minimal.c
+++ b/High Level Prototypes/kaem-minimal.c
@@ -29,8 +29,6 @@
 #define max_args 256
 //CONSTANT max_args 256
 
-void file_print(char* s, FILE* f);
-
 char** tokens;
 int command_done;
 
@@ -130,14 +128,14 @@ main_loop:
 
 	if(0 > i) goto main_loop;
 
-	file_print(" +> ", stdout);
+	fputs(" +> ", stdout);
 	int j;
 	for(j = 0; j < i; j = j + 1)
 	{
-		file_print(tokens[j], stdout);
+		fputs(tokens[j], stdout);
 		fputc(' ', stdout);
 	}
-	file_print("\n", stdout);
+	fputs("\n", stdout);
 
 	char* program = tokens[0];
 	if(NULL == program) exit(EXIT_FAILURE);
@@ -159,7 +157,7 @@ main_loop:
 	if(0 == status) goto main_loop;
 
 	/* Clearly the script hit an issue that should never have happened */
-	file_print("Subprocess error\nABORTING HARD\n", stderr);
+	fputs("Subprocess error\nABORTING HARD\n", stderr);
 	/* stop to prevent damage */
 	exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
The High Level Prototypes still used `file_print` which has been refactored to `fputs` in M2libc meanwhile.

Also add a Makefile for those who want to build the high level prototypes.