### PR TITLE
kaem-micro for riscv64.

### DIFF
--- a/riscv64/Development/kaem-micro.M1
+++ b/riscv64/Development/kaem-micro.M1
@@ -1,0 +1,265 @@
+## Copyright (C) 2021 Andrius Štikonas
+## This file is part of stage0.
+##
+## stage0 is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## stage0 is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with stage0.  If not, see <http://www.gnu.org/licenses/>.
+
+;; Used to terminate word
+DEFINE NULL  00000000
+DEFINE NULL64 0000000000000000
+
+;; Opcodes
+
+;; RV32I Base Instruction Set
+DEFINE LUI   37000000
+DEFINE AUIPC 17000000
+DEFINE JAL   6F000000
+DEFINE JALR  67000000
+DEFINE BEQ   63000000
+DEFINE BNE   63100000
+DEFINE BLT   63400000
+DEFINE BGE   63500000
+DEFINE BLTU  63600000
+DEFINE BGEU  63700000
+DEFINE LB    03000000
+DEFINE LH    03100000
+DEFINE LW    03200000
+DEFINE LBU   03400000
+DEFINE LHU   03500000
+DEFINE SB    23000000
+DEFINE SH    23100000
+DEFINE SW    23200000
+DEFINE ADDI  13000000
+DEFINE SLTI  13200000
+DEFINE SLTIU 13300000
+DEFINE XORI  13400000
+DEFINE ORI   13600000
+DEFINE ANDI  13700000
+DEFINE SLLI  13100000
+DEFINE SRLI  13500000
+DEFINE SRAI  13500040
+DEFINE ADD   33000000
+DEFINE SUB   33000040
+DEFINE SLL   33100000
+DEFINE SLT   33200000
+DEFINE SLTU  33300000
+DEFINE XOR   33400000
+DEFINE SRL   33500000
+DEFINE SRA   33500040
+DEFINE OR    33600000
+DEFINE AND   33700000
+DEFINE ECALL 73000000
+
+;; RV64I Base Instruction set
+DEFINE LWU   03600000
+DEFINE LD    03300000
+DEFINE SD    23300000
+DEFINE ADDIW 1B000000
+DEFINE SLLI  13100000
+DEFINE SRLI  13500000
+DEFINE SRAI  13500040
+DEFINE ADDW  3B000000
+DEFINE SUBW  3B000040
+DEFINE SLLW  3B100000
+DEFINE SRL   3B500000
+DEFINE SRAW  3B500040
+
+;; Pseudoinstructions
+DEFINE NOP  13000000 # ADDI
+DEFINE MV   13000000 # ADDI
+DEFINE NOT  1340F0FF # XORI, RD, RS, -1
+DEFINE BEQZ 63000000 # BEQ
+DEFINE BNEZ 63100000 # BNE
+DEFINE BLTZ 63400000 # BLT
+
+;; Destination registers
+;; register_number << 7
+DEFINE RD_RA  .80000000
+DEFINE RD_SP  .00010000
+DEFINE RD_GP  .80010000
+DEFINE RD_TP  .00020000
+DEFINE RD_T0  .80020000
+DEFINE RD_T1  .00030000
+DEFINE RD_T2  .80030000
+DEFINE RD_S0  .00040000
+DEFINE RD_S1  .80040000
+DEFINE RD_A0  .00050000
+DEFINE RD_A1  .80050000
+DEFINE RD_A2  .00060000
+DEFINE RD_A3  .80060000
+DEFINE RD_A4  .00070000
+DEFINE RD_A5  .80070000
+DEFINE RD_A6  .00080000
+DEFINE RD_A7  .80080000
+DEFINE RD_S2  .00090000
+DEFINE RD_S3  .80090000
+DEFINE RD_S4  .000A0000
+DEFINE RD_S5  .800A0000
+DEFINE RD_S6  .000B0000
+DEFINE RD_S7  .800B0000
+DEFINE RD_S8  .000C0000
+DEFINE RD_S9  .800C0000
+DEFINE RD_S10 .000D0000
+DEFINE RD_S11 .800D0000
+DEFINE RD_T3  .000E0000
+DEFINE RD_T4  .800E0000
+DEFINE RD_T5  .000F0000
+DEFINE RD_T6  .800F0000
+
+;; First source registers
+;; register_number << 15
+DEFINE RS1_RA  .00800000
+DEFINE RS1_SP  .00000100
+DEFINE RS1_GP  .00800100
+DEFINE RS1_TP  .00000200
+DEFINE RS1_T0  .00800200
+DEFINE RS1_T1  .00000300
+DEFINE RS1_T2  .00800300
+DEFINE RS1_S0  .00000400
+DEFINE RS1_S1  .00800400
+DEFINE RS1_A0  .00000500
+DEFINE RS1_A1  .00800500
+DEFINE RS1_A2  .00000600
+DEFINE RS1_A3  .00800600
+DEFINE RS1_A4  .00000700
+DEFINE RS1_A5  .00800700
+DEFINE RS1_A6  .00000800
+DEFINE RS1_A7  .00800800
+DEFINE RS1_S2  .00000900
+DEFINE RS1_S3  .00800900
+DEFINE RS1_S4  .00000A00
+DEFINE RS1_S5  .00800A00
+DEFINE RS1_S6  .00000B00
+DEFINE RS1_S7  .00800B00
+DEFINE RS1_S8  .00000C00
+DEFINE RS1_S9  .00800C00
+DEFINE RS1_S10 .00000D00
+DEFINE RS1_S11 .00800D00
+DEFINE RS1_T3  .00000E00
+DEFINE RS1_T4  .00800E00
+DEFINE RS1_T5  .00000F00
+DEFINE RS1_T6  .00800F00
+
+;; Second source registers
+;; register_number << 20
+DEFINE RS2_RA  .00001000
+DEFINE RS2_SP  .00002000
+DEFINE RS2_GP  .00003000
+DEFINE RS2_TP  .00004000
+DEFINE RS2_T0  .00005000
+DEFINE RS2_T1  .00006000
+DEFINE RS2_T2  .00007000
+DEFINE RS2_S0  .00008000
+DEFINE RS2_S1  .00009000
+DEFINE RS2_A0  .0000A000
+DEFINE RS2_A1  .0000B000
+DEFINE RS2_A2  .0000C000
+DEFINE RS2_A3  .0000D000
+DEFINE RS2_A4  .0000E000
+DEFINE RS2_A5  .0000F000
+DEFINE RS2_A6  .00000001
+DEFINE RS2_A7  .00001001
+DEFINE RS2_S2  .00002001
+DEFINE RS2_S3  .00003001
+DEFINE RS2_S4  .00004001
+DEFINE RS2_S5  .00005001
+DEFINE RS2_S6  .00006001
+DEFINE RS2_S7  .00007001
+DEFINE RS2_S8  .00008001
+DEFINE RS2_S9  .00009001
+DEFINE RS2_S10 .0000A001
+DEFINE RS2_S11 .0000B001
+DEFINE RS2_T3  .0000C001
+DEFINE RS2_T4  .0000D001
+DEFINE RS2_T5  .0000E001
+DEFINE RS2_T6  .0000F001
+
+; Where the ELF Header is going to hit
+; Simply jump to _start
+; Our main function
+:_start
+
+# This is not a real kaem but instead a small hardcoded script to build
+# and launch kaem-minimal.
+# It first uses hex0-seed to build hex0.
+# Then uses hex0 to build kaem-minimal and starts it.
+
+# It expects hex0_riscv64.hex0 and kaem-minimal.hex0 files to be in the current directory.
+# Path to hex0-seed is assumed to be ../bootstrap-seeds/POSIX/riscv64/hex0-seed
+# However it is the last thing in the binary, so updating it is trivial and
+# does not affect anything else in the file.
+
+# Register use:
+# s1: address to pointer array of program and arguments to be executed
+# s2: have_hex0
+
+    RD_S1 ~argv_hex0 AUIPC            # hex0-seed hex0_riscv64.hex0 hex0
+    RD_S1 RS1_S1 !argv_hex0 ADDI
+    $clone JAL                        # jump to clone
+
+:kaem_minimal
+    RD_S1 ~argv_kaem AUIPC            # hex0 kaem-minimal.hex0 kaem
+    RD_S1 RS1_S1 !argv_kaem ADDI
+
+    RD_S2 RS1_S2 NOT                  # s2 = !s2
+
+:clone
+    RD_A7 !220 ADDI                   # sys_clone
+    RD_A0 !17 ADDI                    # SIGCHLD flag
+    ECALL                             # syscall
+
+    RS1_A0 @parent BNEZ               # if f == 0 it is child
+
+    # Deal with child case
+:execve
+    RD_A0 RS1_S1 LD                   # program
+
+    RD_A7 !221 ADDI                   # sys_execve
+    RD_A1 RS1_S1 MV                   # argv
+    ECALL                             # execve(program, argv)
+
+    # Terminate child program (only happens on error)
+    RD_A7 !93 ADDI                    # sys_exit
+    ECALL                             # exit(1)
+
+:parent
+    RD_A7 !260 ADDI                   # sys_wait4
+    ECALL                             # syscall
+    RS1_S2 @kaem_minimal BEQZ         # Now build kaem
+
+:start_kaem
+    RD_S1 ~argv_kaem_minimal AUIPC    # kaem
+    RD_S1 RS1_S1 !argv_kaem_minimal ADDI
+    $execve JAL                       # execve into kaem-minimal
+
+# PROGRAM END
+
+:argv_hex0
+    &hex0_seed %0
+    &hex0_source %0
+    &hex0_out %0
+    NULL64
+
+:argv_hex0
+    &hex0_out %0
+    &kaem_source %0
+:argv_kaem_minimal
+    &kaem_out %0
+    NULL64
+
+:hex0_source "hex0_riscv64.hex0"
+:hex0_out "hex0"
+:kaem_source "kaem-minimal.hex0"
+:kaem_out "kaem"
+# Put this one last to make updating hardcoded path trivial
+:hex0_seed "../bootstrap-seeds/POSIX/riscv64/hex0-seed"

--- a/riscv64/Development/kaem-micro.hex2
+++ b/riscv64/Development/kaem-micro.hex2
@@ -1,0 +1,148 @@
+## Copyright (C) 2021 Andrius Štikonas
+## This file is part of stage0.
+##
+## stage0 is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## stage0 is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with stage0.  If not, see <http://www.gnu.org/licenses/>.
+
+# This is not a real kaem but instead a small hardcoded script to build
+# and launch kaem-minimal.
+# It first uses hex0-seed to build hex0.
+# Then uses hex0 to build kaem-minimal and starts it.
+
+# It expects hex0_riscv64.hex0 and kaem-minimal.hex0 files to be in the current directory.
+# However it is the last thing in the binary, so updating it is trivial and
+# does not affect anything else in the file.
+
+# Register use:
+# s1: address to pointer array of program and arguments to be executed
+# s2: have_hex0
+
+## ELF Header
+#:ELF_base
+7F 45 4C 46        ## e_ident[EI_MAG0-3] ELF's magic number
+
+02                 ## e_ident[EI_CLASS] Indicating 64 bit
+01                 ## e_ident[EI_DATA] Indicating little endianness
+01                 ## e_ident[EI_VERSION] Indicating original elf
+
+03                 ## e_ident[EI_OSABI] Set at 3 for Linux
+00                 ## e_ident[EI_ABIVERSION] Ignored for Statically linked executables
+
+00 00 00 00 00 00 00 ## e_ident[EI_PAD]
+02 00              ## e_type Indicating Executable
+F3 00              ## e_machine Indicating RISC-V
+01 00 00 00        ## e_version Indicating original elf
+
+78 00 60 00 00 00 00 00 ## e_entry Address of the entry point (Number of bytes this header is + Base Address) # TODO
+40 00 00 00 00 00 00 00 ## e_phoff Address of program header table
+00 00 00 00 00 00 00 00 ## e_shoff Address of section header table
+
+00 00 00 00        ## e_flags
+40 00              ## e_ehsize Indicating our 64 Byte header
+
+38 00              ## e_phentsize size of a program header table
+01 00              ## e_phnum number of entries in program table
+
+00 00              ## e_shentsize size of a section header table
+00 00              ## e_shnum number of entries in section table
+
+00 00              ## e_shstrndx index of the section names
+
+## Program Header
+#:ELF_program_headers
+01 00 00 00             ## p_type
+07 00 00 00             ## Flags
+00 00 00 00 00 00 00 00 ## p_offset
+
+00 00 60 00 00 00 00 00 ## p_vaddr
+00 00 60 00 00 00 00 00 ## p_physaddr
+
+0E 02 00 00 00 00 00 00 ## p_filesz
+0E 02 00 00 00 00 00 00 ## p_memsz
+
+01 00 00 00 00 00 00 00 ## Required alignment
+
+#:ELF_text
+:_start
+
+    ~argv_hex0 97 04 00 00 # RD_S1 ~argv_hex0 AUIPC     ; hex0-seed hex0_riscv64.hex0 hex0
+    !argv_hex0 93 84 04 00 # RD_S1 RS1_S1 !argv_hex0 ADDI
+    $clone 6F 00 00 00 # $clone JAL                     ; jump to clone
+
+:kaem_minimal
+    ~argv_kaem 97 04 00 00 # RD_S1 ~argv_kaem AUIPC     ; hex0 kaem-minimal.hex0 kaem
+    !argv_kaem 93 84 04 00 # RD_S1 RS1_S1 !argv_kaem ADDI
+
+    13 49 F9 FF     # RD_S2 RS1_S2 NOT                  ; s2 = !s2
+
+:clone
+    93 08 C0 0D     # RD_A7 !220 ADDI                   ; sys_clone
+    13 05 10 01     # RD_A0 !17 ADDI                    ; SIGCHLD flag
+    73 00 00 00     # ECALL                             ; syscall
+
+    @parent 63 10 05 00 # RS1_A0 @parent BNEZ           ; if f == 0 it is child
+
+    # Deal with child case
+:execve
+    03 B5 04 00     # RD_A0 RS1_S1 LD                   ; program
+
+    93 08 D0 0D     # RD_A7 !221 ADDI                   ; sys_execve
+    93 85 04 00     # RD_A1 RS1_S1 MV                   ; argv
+    73 00 00 00     # ECALL                             ; execve(program, argv)
+
+    # Terminate child program (only happens on error)
+    93 08 D0 05     # RD_A7 !93 ADDI                    ; sys_exit
+    73 00 00 00     # ECALL                             ; syscall
+
+:parent
+    93 08 40 10     # RD_A7 !260 ADDI                   ; sys_wait4
+    73 00 00 00     # ECALL                             ; syscall
+    @kaem_minimal 63 00 09 00 # RS1_S2 @kaem_minimal BEQZ ; Now build kaem
+
+:start_kaem
+    ~argv_kaem_minimal 97 04 00 00 # RD_S1 ~argv_kaem_minimal AUIPC ; kaem
+    !argv_kaem_minimal 93 84 04 00 # RD_S1 RS1_S1 !argv_kaem_minimal ADDI
+    $execve 6F 00 00 00 # $execve JAL                   ; execve into kaem-minimal
+
+# PROGRAM END
+
+:argv_hex0
+    &hex0_seed 00 00 00 00
+    &hex0_source 00 00 00 00
+    &hex0_out 00 00 00 00
+    00 00 00 00 00 00 00 00
+
+:argv_kaem
+    &hex0_out 00 00 00 00
+    &kaem_source 00 00 00 00
+:argv_kaem_minimal
+    &kaem_out 00 00 00 00
+    00 00 00 00 00 00 00 00
+
+:hex0_source
+    68 65 78 30 5F 72 69 73 63 76 36 34 2E 68 65 78 30 00 ; hex0_riscv64.hex0
+
+:hex0_out
+    68 65 78 30 00                                        ; hex0
+
+:kaem_source
+    6B 61 65 6D 2D 6D 69 6E 69 6D 61 6C 2E 68 65 78 30 00 ; kaem-minimal.hex0
+
+:kaem_out
+    6B 61 65 6D 00                                        ; kaem
+
+# Put this one last to make updating hardcoded path trivial
+:hex0_seed
+    2E 2E 2F 62 6F 6F 74 73 74 72 61 70 2D 73 65 65 64 73
+    2F 50 4F 53 49 58 2F 72 69 73 63 76 36 34 2F 68 65 78
+    30 2D 73 65 65 64 00                                  ; ../bootstrap-seeds/POSIX/riscv64/hex0-seed

--- a/riscv64/GAS/kaem-micro.S
+++ b/riscv64/GAS/kaem-micro.S
@@ -1,0 +1,88 @@
+## Copyright (C) 2021 Andrius Štikonas
+## This file is part of stage0.
+##
+## stage0 is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## stage0 is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with stage0.  If not, see <http://www.gnu.org/licenses/>.
+
+# This is not a real kaem but instead a small hardcoded script to build
+# and launch kaem-minimal.
+# It first uses hex0-seed to build hex0.
+# Then uses hex0 to build kaem-minimal and starts it.
+
+# It expects hex0_riscv64.hex0 and kaem-minimal.hex0 files to be in the current directory.
+# Path to hex0-seed is assumed to be ../bootstrap-seeds/POSIX/riscv64/hex0-seed
+# However it is the last thing in the binary, so updating it is trivial and
+# does not affect anything else in the file.
+
+# Register use:
+# s1: address to pointer array of program and arguments to be executed
+# s2: have_hex0
+
+.text
+.global _start
+_start:
+    la s1, argv_hex0                  # hex0-seed hex0_riscv64.hex0 hex0
+    j clone                           # jump to clone
+
+kaem_minimal:
+    la s1, argv_kaem                  # hex0 kaem-minimal.hex0 kaem
+    not s2, s2                        # s2 = !s2
+
+clone:
+    li a7, 220                        # sys_clone
+    li a0, 17                         # SIGCHLD flag
+    ecall                             # syscall
+
+    bnez a0, parent                   # if f == 0 it is child
+
+    # Deal with child case
+execve:
+    ld a0, (s1)                       # program
+
+    li a7, 221                        # sys_execve
+    mv a1, s1                         # argv
+    ecall                             # execve(program, argv)
+
+    # Terminate child program (only happens on error)
+    li a7, 93                         # sys_exit
+    ecall                             # exit(1)
+
+parent:
+    li a7, 260                        # sys_wait4
+    ecall                             # syscall
+    beqz s2, kaem_minimal             # Now build kaem
+
+start_kaem:
+    la s1, argv_kaem_minimal          # argv
+    j execve                          # execve into kaem-minimal
+
+# PROGRAM END
+
+argv_hex0:
+    .quad hex0_seed
+    .quad hex0_source
+    .quad hex0_out
+    .quad 0
+
+argv_kaem:
+    .quad hex0_out
+    .quad kaem_source
+argv_kaem_minimal:
+    .quad kaem_out
+    .quad 0
+
+hex0_seed: .asciz "../bootstrap-seeds/POSIX/riscv64/hex0-seed"
+hex0_source: .asciz "hex0_riscv64.hex0"
+hex0_out: .asciz "hex0"
+kaem_source: .asciz "kaem-minimal.hex0"
+kaem_out: .asciz "kaem"

--- a/riscv64/kaem-micro.hex0
+++ b/riscv64/kaem-micro.hex0
@@ -1,0 +1,156 @@
+## Copyright (C) 2021 Andrius Štikonas
+## This file is part of stage0.
+##
+## stage0 is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## stage0 is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with stage0.  If not, see <http://www.gnu.org/licenses/>.
+
+# This is not a real kaem but instead a small hardcoded script to build
+# and launch kaem-minimal.
+# It first uses hex0-seed to build hex0.
+# Then uses hex0 to build kaem-minimal and starts it.
+
+# It expects hex0_riscv64.hex0 and kaem-minimal.hex0 files to be in the current directory.
+# Path to hex0-seed is assumed to be ../bootstrap-seeds/POSIX/riscv64/hex0-seed
+# However it is the last thing in the binary, so updating it is trivial and
+# does not affect anything else in the file.
+
+# Register use:
+# s1: address to pointer array of program and arguments to be executed
+# s2: have_hex0
+
+## ELF Header
+#:ELF_base
+7F 45 4C 46        ## e_ident[EI_MAG0-3] ELF's magic number
+
+02                 ## e_ident[EI_CLASS] Indicating 64 bit
+01                 ## e_ident[EI_DATA] Indicating little endianness
+01                 ## e_ident[EI_VERSION] Indicating original elf
+
+03                 ## e_ident[EI_OSABI] Set at 3 for Linux
+00                 ## e_ident[EI_ABIVERSION] Ignored for Statically linked executables
+
+00 00 00 00 00 00 00 ## e_ident[EI_PAD]
+02 00              ## e_type Indicating Executable
+F3 00              ## e_machine Indicating RISC-V
+01 00 00 00        ## e_version Indicating original elf
+
+78 00 60 00 00 00 00 00 ## e_entry Address of the entry point (Number of bytes this header is + Base Address) # TODO
+40 00 00 00 00 00 00 00 ## e_phoff Address of program header table
+00 00 00 00 00 00 00 00 ## e_shoff Address of section header table
+
+00 00 00 00        ## e_flags
+40 00              ## e_ehsize Indicating our 64 Byte header
+
+38 00              ## e_phentsize size of a program header table
+01 00              ## e_phnum number of entries in program table
+
+00 00              ## e_shentsize size of a section header table
+00 00              ## e_shnum number of entries in section table
+
+00 00              ## e_shstrndx index of the section names
+
+## Program Header
+#:ELF_program_headers
+01 00 00 00             ## p_type
+07 00 00 00             ## Flags
+00 00 00 00 00 00 00 00 ## p_offset
+
+00 00 60 00 00 00 00 00 ## p_vaddr
+00 00 60 00 00 00 00 00 ## p_physaddr
+
+0E 02 00 00 00 00 00 00 ## p_filesz
+0E 02 00 00 00 00 00 00 ## p_memsz
+
+01 00 00 00 00 00 00 00 ## Required alignment
+
+#:ELF_text
+# :_start ; (0x0600078)
+
+    97 04 00 00     # RD_S1 ~argv_hex0 AUIPC            ; hex0-seed hex0_riscv64.hex0 hex0    
+    93 84 84 05     # RD_S1 RS1_S1 !argv_hex0 ADDI      # +88B
+
+    6F 00 00 01     # $clone JAL                        ; jump to clone
+                    # +16B
+
+# :kaem_minimal ; (0x0600084)
+    97 04 00 00     # RD_S1 ~argv_kaem AUIPC            ; hex0 kaem-minimal.hex0 kaem
+    93 84 C4 06     # RD_S1 RS1_S1 !argv_kaem ADDI
+                    # +108B
+
+    13 49 F9 FF     # RD_S2 RS1_S2 NOT                  ; s2 = !s2
+
+# :clone ; (0x0600090)
+    93 08 C0 0D     # RD_A7 !220 ADDI                   ; sys_clone
+    13 05 10 01     # RD_A0 !17 ADDI                    ; SIGCHLD flag
+    73 00 00 00     # ECALL                             ; syscall
+
+    63 1E 05 00     # RS1_A0 @parent BNEZ               ; if f == 0 it is child
+                    # +28B
+
+    # Deal with child case
+# :execve ; (0x06000a0)
+    03 B5 04 00     # RD_A0 RS1_S1 LD                   ; program
+
+    93 08 D0 0D     # RD_A7 !221 ADDI                   ; sys_execve
+    93 85 04 00     # RD_A1 RS1_S1 MV                   ; argv
+    73 00 00 00     # ECALL                             ; execve(program, argv)
+
+    # Terminate child program (only happens on error)
+    93 08 D0 05     # RD_A7 !93 ADDI                    ; sys_exit
+    73 00 00 00     # ECALL                             ; syscall
+
+# :parent ; (0x06000b8)
+    93 08 40 10     # RD_A7 !260 ADDI                   ; sys_wait4
+    73 00 00 00     # ECALL                             ; syscall
+    E3 02 09 FC     # RS1_S2 @kaem_minimal BEQZ         ; Now build kaem
+                    # -60B
+
+# :start_kaem ; (0x06000c4)
+    97 04 00 00     # RD_S1 ~argv_kaem_minimal AUIPC ; kaem
+    93 84 C4 03     # RD_S1 RS1_S1 !argv_kaem_minimal ADDI
+                    # +60B
+    6F F0 5F FD     # $execve JAL                       ; execve into kaem-minimal
+                    # -44B
+
+# PROGRAM END
+
+# :argv_hex0 ; (0x06000d0)
+    3E 01 60 00 00 00 00 00    # &hex0_seed
+    10 01 60 00 00 00 00 00    # &hex0_source ; (0x06000d8)
+    22 01 60 00 00 00 00 00    # &hex0_out    ; (0x06000e0)
+    00 00 00 00 00 00 00 00
+
+# :argv_kaem ; (0x06000f0)
+    22 01 60 00 00 00 00 00    # &hex0_out
+    27 01 60 00 00 00 00 00    # &kaem_source  ; (0x06000f8)
+# :argv_kaem_minimal ; (0x0600100)
+    39 01 60 00 00 00 00 00    # &kaem_out
+    00 00 00 00 00 00 00 00
+
+# :hex0_source ; (0x0600110)
+    68 65 78 30 5F 72 69 73 63 76 36 34 2E 68 65 78 30 00 ; hex0_riscv64.hex0
+
+# :hex0_out ; (0x0600122)
+    68 65 78 30 00                                        ; hex0
+
+# :kaem_source ; (0x0600127)
+    6B 61 65 6D 2D 6D 69 6E 69 6D 61 6C 2E 68 65 78 30 00 ; kaem-minimal.hex0
+
+# :kaem_out ; (0x0600139)
+    6B 61 65 6D 00                                        ; kaem
+
+# Put this one last to make updating hardcoded path trivial
+# :hex0_seed ; (0x060013e)
+    2E 2E 2F 62 6F 6F 74 73 74 72 61 70 2D 73 65 65 64 73
+    2F 50 4F 53 49 58 2F 72 69 73 63 76 36 34 2F 68 65 78
+    30 2D 73 65 65 64 00                                  ; ../bootstrap-seeds/POSIX/riscv64/hex0-seed

--- a/riscv64/kaem.run
+++ b/riscv64/kaem.run
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+# Copyright © 2021 Andrius Štikonas
+
+# stage0 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# stage0 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with stage0.  If not, see <http://www.gnu.org/licenses/>.
+
+# Can also be run by kaem or any other shell of your personal choice
+# To run in kaem simply: kaem --verbose --strict
+
+###########################################################
+# Phase 0 Build kaem and hex0 from bootstrapped binaries  #
+# This phase is run by kaem-optional-seed (kaem-micro)    #
+# hex0-seed hex0_riscv64.hex0 hex0                        #
+# hex0-seed kaem-minimal.hex0 kaem                        #
+# kaem                                                    #
+###########################################################
+
+###########################################################
+# Phase 1 Rebuild kaem-micro                              #
+###########################################################
+
+hex0 kaem-micro.hex0 kaem-micro


### PR DESCRIPTION
I'm somewhat unhappy about having to hardcode path to hex0-seed. Any ideas? Extracting it (with the assumption that it is in the same folder as kaem-optional-seed) is possibly, but would probably make binary somewhat bigger.