### PR TITLE
Fix a bug in RISC-V U encoding with negative values.

### DIFF
--- a/riscv64/Development/M0_riscv64.M1
+++ b/riscv64/Development/M0_riscv64.M1
@@ -940,7 +940,7 @@ DEFINE RS2_X31 .0000F001
 
     ; Deal with sign extension: add 0x1000
     RD_T0 ~0x1000 LUI
-    RD_A0 RS1_T0 RS2_A0 ADD           ; (value & 0xfffff000) + 0x1000
+    RD_A0 RS1_T0 RS2_A0 ADDW          ; (value & 0xfffff000) + 0x1000
 :express_number_U_small
     RD_RA $hex32l JAL                 ; Store 32-bits
     $express_number_done JAL          ; done

--- a/riscv64/Development/hex1_riscv64.M1
+++ b/riscv64/Development/hex1_riscv64.M1
@@ -503,7 +503,7 @@ DEFINE RS2_X31 .0000F001
 
     # Deal with sign extension: add 0x1000
     RD_T0 ~0x1000 LUI                 ; load higher bits
-    RD_S7 RS1_T0 RS2_S7 ADD           ; (value & 0xfffff000) + 0x1000
+    RD_S7 RS1_T0 RS2_S7 ADDW          ; (value & 0xfffff000) + 0x1000
 
 :UpdateShiftRegister_U_small
     RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword

--- a/riscv64/Development/hex1_riscv64.hex2
+++ b/riscv64/Development/hex1_riscv64.hex2
@@ -349,7 +349,7 @@ F3 00              ## e_machine Indicating RISC-V
 
     # Deal with sign extension: add 0x1000
     B7 12 00 00     # RD_T0 ~0x1000 LUI                 ; load higher bits
-    B3 8B 72 01     # RD_S7 RS1_T0 RS2_S7 ADD           ; (value & 0xfffff000) + 0x1000
+    BB 8B 72 01     # RD_S7 RS1_T0 RS2_S7 ADDW          ; (value & 0xfffff000) + 0x1000
 
 :UpdateShiftRegister_U_small
     33 4C 7C 01     # RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword

--- a/riscv64/Development/hex2_riscv64.M1
+++ b/riscv64/Development/hex2_riscv64.M1
@@ -653,7 +653,7 @@ DEFINE RS2_X31 .0000F001
 
     # Deal with sign extension: add 0x1000
     RD_T0 ~0x1000 LUI                 ; load higher bits
-    RD_S7 RS1_T0 RS2_S7 ADD           ; (value & 0xfffff000) + 0x1000
+    RD_S7 RS1_T0 RS2_S7 ADDW          ; tempword = (value & 0xfffff000) + 0x1000
 
 :UpdateShiftRegister_U_small
     RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword

--- a/riscv64/Development/hex2_riscv64.hex2
+++ b/riscv64/Development/hex2_riscv64.hex2
@@ -499,7 +499,7 @@ F3 00              ## e_machine Indicating RISC-V
 
     # Deal with sign extension: add 0x1000
     B7 12 00 00     # RD_T0 ~0x1000 LUI                 ; load higher bits
-    B3 8B 72 01     # RD_S7 RS1_T0 RS2_S7 ADD           ; (value & 0xfffff000) + 0x1000
+    BB 8B 72 01     # RD_S7 RS1_T0 RS2_S7 ADDW          ; (value & 0xfffff000) + 0x1000
 
 :UpdateShiftRegister_U_small
     33 4C 7C 01     # RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword

--- a/riscv64/GAS/M0_riscv64.S
+++ b/riscv64/GAS/M0_riscv64.S
@@ -731,7 +731,7 @@ express_number_U:
 
     # Deal with sign extension: add 0x1000
     li t0, 0x1000
-    add a0, t0, a0                    # (value & 0xfffff000) + 0x1000
+    addw a0, t0, a0                   # (value & 0xfffff000) + 0x1000
 express_number_U_small:
     jal hex32l                        # Store 32-bits
     j express_number_done             # done

--- a/riscv64/GAS/hex1_riscv64.S
+++ b/riscv64/GAS/hex1_riscv64.S
@@ -294,7 +294,7 @@ UpdateShiftRegister_U:
 
     # Deal with sign extension: add 0x1000
     li t0, 0x1000
-    add s7, t0, s7               # (value & 0xfffff000) + 0x1000
+    addw s7, t0, s7              # (value & 0xfffff000) + 0x1000
 
 UpdateShiftRegister_U_small:
     xor s8, s8, s7               # shiftregister = shiftregister ^ tempword

--- a/riscv64/GAS/hex2_riscv64.S
+++ b/riscv64/GAS/hex2_riscv64.S
@@ -437,7 +437,7 @@ UpdateShiftRegister_U:
 
     # Deal with sign extension: add 0x1000
     li t0, 0x1000
-    add s7, t0, s7               # (value & 0xfffff000) + 0x1000
+    addw s7, t0, s7              # (value & 0xfffff000) + 0x1000
 
 UpdateShiftRegister_U_small:
     xor s8, s8, s7               # shiftregister = shiftregister ^ tempword

--- a/riscv64/M0_riscv64.hex2
+++ b/riscv64/M0_riscv64.hex2
@@ -1180,8 +1180,8 @@
     ; Deal with sign extension: add 0x1000
     # RD_T0 ~0x1000 LUI
     .80020000 .00100000 37000000
-    # RD_A0 RS1_T0 RS2_A0 ADD           ; (value & 0xfffff000) + 0x1000
-    .00050000 .00800200 .0000A000 33000000
+    # RD_A0 RS1_T0 RS2_A0 ADDW          ; (value & 0xfffff000) + 0x1000
+    .00050000 .00800200 .0000A000 3B000000
 :express_number_U_small
     # RD_RA $hex32l JAL                 ; Store 32-bits
     .80000000 $hex32l 6F000000

--- a/riscv64/hex1_riscv64.hex0
+++ b/riscv64/hex1_riscv64.hex0
@@ -389,7 +389,7 @@ C1 04 00 00 00 00 00 00 ## p_memsz
 
     # Deal with sign extension: add 0x1000
     B7 12 00 00     # RD_T0 ~0x1000 LUI                 ; load higher bits
-    B3 8B 72 01     # RD_S7 RS1_T0 RS2_S7 ADD           ; (value & 0xfffff000) + 0x1000
+    BB 8B 72 01     # RD_S7 RS1_T0 RS2_S7 ADDW          ; (value & 0xfffff000) + 0x1000
 
 # :UpdateShiftRegister_U_small ; (0x06002D4)
     33 4C 7C 01     # RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword

--- a/riscv64/hex2_riscv64.hex1
+++ b/riscv64/hex2_riscv64.hex1
@@ -499,7 +499,7 @@ FC 07 00 00 00 00 00 00 ## p_memsz
 
     # Deal with sign extension: add 0x1000
     B7 12 00 00     # RD_T0 ~0x1000 LUI                 ; load higher bits
-    B3 8B 72 01     # RD_S7 RS1_T0 RS2_S7 ADD           ; (value & 0xfffff000) + 0x1000
+    BB 8B 72 01     # RD_S7 RS1_T0 RS2_S7 ADDW          ; (value & 0xfffff000) + 0x1000
 
 :u ;UpdateShiftRegister_U_small
     33 4C 7C 01     # RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword


### PR DESCRIPTION
Correct behaviour relies on 32-bit value overflow.