### PR TITLE
Build M2-Planet for RISC-V

### DIFF
--- a/riscv64/.gitignore
+++ b/riscv64/.gitignore
@@ -6,4 +6,7 @@ hex2-0
 catm
 M0
 hold*
+temp1
 cc_riscv64
+M2
+M2.M1

--- a/riscv64/Development/M0_riscv64.M1
+++ b/riscv64/Development/M0_riscv64.M1
@@ -25,6 +25,7 @@
 ; s3: output fd
 ; s4: struct HEAD
 ; s5: protected char
+; s6: scratch
 
 ; Struct format: (size 32)
 ; NEXT => 0                           ; Next element in linked list
@@ -77,6 +78,10 @@
     RD_A0 ADDI                        ; Get current brk
     ECALL                             ; syscall
     RD_S1 RS1_A0 MV                   ; Set our malloc pointer
+
+    RD_A0 !512 ADDI                   ; Allocate scratch
+    RD_RA $malloc JAL                 ; Get S pointer
+    RD_S6 RS1_A0 MV                   ; Save scratch pointer
 
     RD_RA $Tokenize_Line JAL          ; Get all lines
     RD_A0 RS1_S4 MV                   ; Prepare for Reverse_List
@@ -191,11 +196,8 @@
 
     RD_A0 !2 ADDI                     ; Using TYPE STRING
     RS1_A3 RS2_A0 @8 SD               ; HEAD->TYPE = STRING
-    RD_A0 !256 ADDI                   ; Malloc the string
-    RD_RA $malloc JAL                 ; Get pointer to P
-    RS1_A3 RS2_A0 @16 SD              ; HEAD->TEXT = STRING
     RD_A1 RS1_A2 MV                   ; Protect terminator
-    RD_A3 RS1_A0 MV                   ; Protect string pointer
+    RD_A3 RS1_S6 MV                   ; Protect string pointer
 :Store_String_Loop
     RS1_A3 RS2_A2 SB                  ; write byte
     RD_RA $fgetc JAL                  ; read next char
@@ -203,11 +205,71 @@
     RD_A3 RS1_A3 !1 ADDI              ; STRING = STRING + 1
     RS1_A1 RS2_A2 @Store_String_Loop BNE ; Keep looping unless we hit terminator
 
+    RD_A0 RS1_S6 MV                   ; Prepare the string in scratch
+    RD_RA $string_length JAL          ; Calculate length
+    RD_A0 RS1_A0 !1 ADDI              ; Add 1 for 0 terminator
+    RD_RA $malloc JAL                 ; Allocate memory
+    RD_A3 RS1_SP !16 LD               ; restore a3 (HEAD)
+    RS1_A3 RS2_A0 @16 SD              ; HEAD->TEXT = STRING
+    RD_RA $copy_string JAL            ; Copy the string
+
     RD_A1 RS1_SP LD                   ; restore a1
     RD_A2 RS1_SP !8 LD                ; restore a2
-    RD_A3 RS1_SP !16 LD               ; restore a3
     RD_SP RS1_SP !24 ADDI             ; deallocate stack
     $restart JAL
+
+
+; copy_string function
+; Receives target in a0, and scratch s6 for source
+; Uses a0, for target string T, a1 for C, a2 for source string S
+; Returns nothing
+:copy_string
+    RD_SP RS1_SP !-24 ADDI            ; allocate stack
+    RS1_SP RS2_RA SD                  ; protect ra
+    RS1_SP RS2_A1 @8 SD               ; protect a1
+    RS1_SP RS2_A2 @16 SD              ; protect a2
+
+    RD_A2 RS1_S6 MV                   ; Get S
+
+:copy_string_loop
+    RD_A1 RS1_A2 LBU                  ; S[0]
+    RS1_A1 @copy_string_done BEQZ     ; Check if we are done
+
+    RS1_A0 RS2_A1 SB                  ; Copy char
+    RD_A2 RS1_A2 !1 ADDI              ; S = S + 1
+    RD_A0 RS1_A0 !1 ADDI              ; T = T + 1
+    $copy_string_loop JAL             ; Keep going
+
+:copy_string_done
+    RD_RA $ClearScratch JAL           ; Clear scratch
+
+    RD_RA RS1_SP LD                   ; restore ra
+    RD_A1 RS1_SP !8 LD                ; restore a1
+    RD_A2 RS1_SP !16 LD               ; restore a2
+    RD_SP RS1_SP !24 ADDI             ; deallocate stack
+    RETURN
+
+
+; Zero scratch area
+:ClearScratch
+    RD_SP RS1_SP !-24 ADDI            ; allocate stack
+    RS1_SP RS2_RA SD                  ; protect ra
+    RS1_SP RS2_A0 @8 SD               ; protect a0
+    RS1_SP RS2_A1 @16 SD              ; protect a1
+
+    RD_A0 RS1_S6 MV                   ; Prepare scratch
+
+:ClearScratch_loop
+    RD_A1 RS1_A0 LB                   ; Read current byte: s[i]
+    RS1_A0 SB                         ; Write zero: s[i] = 0
+    RD_A0 RS1_A0 !1 ADDI              ; Increment: i = i + 1
+    RS1_A1 @ClearScratch_loop BNEZ    ; Keep looping
+
+    RD_RA RS1_SP LD                   ; restore ra
+    RD_A0 RS1_SP !8 LD                ; restore a0
+    RD_A1 RS1_SP !16 LD               ; restore a1
+    RD_SP RS1_SP !24 ADDI             ; deallocate stack
+    RETURN
 
 
 ; Store_Atom Function
@@ -220,12 +282,9 @@
     RS1_SP RS2_A2 @16 SD              ; protect a2
     RS1_SP RS2_A3 @24 SD              ; protect a3
 
-    RD_A0 !256 ADDI                   ; Malloc the string
-    RD_RA $malloc JAL                 ; Get pointer to P
-    RS1_A3 RS2_A0 @16 SD              ; HEAD->TEXT = STRING
     RD_A1 ~terminators AUIPC          ; Get pointer to "\n\t "
     RD_A1 RS1_A1 !terminators ADDI    ; Get pointer to "\n\t "
-    RD_A3 RS1_A0 MV                   ; Protect string pointer
+    RD_A3 RS1_S6 MV                   ; Protect string pointer
 
 :Store_Atom_loop
     RS1_A3 RS2_A2 SB                  ; write byte
@@ -235,10 +294,17 @@
     RD_RA $In_Set JAL                 ; Check for terminators
     RS1_A0 @Store_Atom_loop BEQZ      ; Loop if not "\n\t "
 
+    RD_A0 RS1_S6 MV                   ; Prepare the string in scratch
+    RD_RA $string_length JAL          ; Calculate length
+    RD_A0 RS1_A0 !1 ADDI              ; Add 1 for 0 terminator
+    RD_RA $malloc JAL                 ; Allocate memory
+    RD_A3 RS1_SP !24 LD               ; restore a3 (HEAD)
+    RS1_A3 RS2_A0 @16 SD              ; HEAD->TEXT = STRING
+    RD_RA $copy_string JAL            ; Copy the string
+
     RD_RA RS1_SP LD                   ; restore ra
     RD_A1 RS1_SP !8 LD                ; restore a1
     RD_A2 RS1_SP !16 LD               ; restore a2
-    RD_A3 RS1_SP !24 LD               ; restore a3
     RD_SP RS1_SP !32 ADDI             ; deallocate stack
     RS1_RA JALR                       ; return
 

--- a/riscv64/Development/hex2_riscv64.M1
+++ b/riscv64/Development/hex2_riscv64.M1
@@ -334,22 +334,22 @@
     ;        ((value >> 8) & 0xff00) |
     ;        ((value << 24) & 0xff000000))
 
-    RD_T2 RS1_A0 RS2_X24 SRLI         ; value >> 24
+    RD_T2 RS1_A0 RS2_X24 SRLIW        ; value >> 24
     RD_T1 !0xFF ADDI                  ; t1 = 0xff
     RD_T0 RS1_T1 RS2_T2 AND           ; (value >> 24) & 0xff
 
-    RD_T2 RS1_A0 RS2_X8 SLLI          ; value << 8
+    RD_T2 RS1_A0 RS2_X8 SLLIW         ; value << 8
     RD_T1 ~0xFF0000 LUI               ; t1 = 0xff0000
     RD_T2 RS1_T1 RS2_T2 AND           ; (value << 8) & 0xff0000
     RD_T0 RS1_T0 RS2_T2 OR            ; logical or with the previous expression
 
-    RD_T2 RS1_A0 RS2_X8 SRLI          ; value >> 8
+    RD_T2 RS1_A0 RS2_X8 SRLIW         ; value >> 8
     RD_T1 ~0xFF00 LUI                 ; t1 = 0xff00
     RD_T1 RS1_T1 !0xFF00 ADDIW        ; t1 = 0xff00
     RD_T2 RS1_T1 RS2_T2 AND           ; (value << 8) & 0xff00
     RD_T0 RS1_T0 RS2_T2 OR            ; logical or with the previous expression
 
-    RD_T2 RS1_A0 RS2_X24 SLLI         ; value << 24
+    RD_T2 RS1_A0 RS2_X24 SLLIW        ; value << 24
     RD_T1 !0xFF ADDI
     RD_T1 RS1_T1 RS2_X24 SLLI         ; t1 = 0xff000000
     RD_T2 RS1_T1 RS2_T2 AND           ; (value << 24) & 0xff000000
@@ -362,12 +362,12 @@
 
 :UpdateShiftRegister_I
     ; Corresponds to RISC-V I format
-    RD_A0 RS1_A0 !4 ADDI              ; add 4 due to this being 2nd part of AUIPC combo
+    RD_A0 RS1_A0 !4 ADDIW             ; add 4 due to this being 2nd part of AUIPC combo
 
     RD_T1 ~0xFFF LUI                  ; load higher bits
     RD_T1 RS1_T1 !0xFFF ADDIW
     RD_T1 RS1_A0 RS2_T1 AND           ; (value & 0xfff)
-    RD_S7 RS1_T1 RS2_X20 SLLI         ; tempword = (value & 0xfff) << 20
+    RD_S7 RS1_T1 RS2_X20 SLLIW        ; tempword = (value & 0xfff) << 20
     RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword
 
     $Second_pass_loop JAL             ; continue looping
@@ -382,22 +382,22 @@
 
     RD_T1 !0x1E ADDI
     RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x1e
-    RD_T0 RS1_T1 RS2_X7 SLLI          ; tempword = (value & 0x1e) << 7
+    RD_T0 RS1_T1 RS2_X7 SLLIW         ; tempword = (value & 0x1e) << 7
 
     RD_T1 !0x7E0 ADDI
     RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x7e0
-    RD_T1 RS1_T1 RS2_X20 SLLI         ; (value & 0x7e0) << (31 - 11)
+    RD_T1 RS1_T1 RS2_X20 SLLIW        ; (value & 0x7e0) << (31 - 11)
     RD_T0 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     RD_T1 ~0x800 LUI                  ; load higher bits
     RD_T1 RS1_T1 !0x800 ADDIW
     RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x800
-    RD_T1 RS1_T1 RS2_X4 SRLI          ; (value & 0x800) >> 4
+    RD_T1 RS1_T1 RS2_X4 SRLIW         ; (value & 0x800) >> 4
     RD_T0 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     RD_T1 ~0x1000 LUI                 ; load higher bits
     RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x1000
-    RD_T1 RS1_T1 RS2_X19 SLLI         ; (value & 0x1000) << (31 - 12)
+    RD_T1 RS1_T1 RS2_X19 SLLIW        ; (value & 0x1000) << (31 - 12)
     RD_S7 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword
@@ -414,12 +414,12 @@
 
     RD_T1 !0x7FE ADDI
     RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x7fe
-    RD_T0 RS1_T1 RS2_X20 SLLI         ; tempword = (value & 0x7fe) << 20
+    RD_T0 RS1_T1 RS2_X20 SLLIW        ; tempword = (value & 0x7fe) << 20
 
     RD_T1 ~0x800 LUI                  ; load higher bits
     RD_T1 RS1_T1 !0x800 ADDIW
     RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x800
-    RD_T1 RS1_T1 RS2_X9 SLLI          ; (value & 0x800) << (20 - 11)
+    RD_T1 RS1_T1 RS2_X9 SLLIW         ; (value & 0x800) << (20 - 11)
     RD_T0 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     RD_T1 ~0xFF000 LUI                ; load higher bits
@@ -428,7 +428,7 @@
 
     RD_T1 ~0x100000 LUI               ; load higher bits
     RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x100000
-    RD_T1 RS1_T1 RS2_X11 SLLI         ; (value & 0x100000) << (31 - 20)
+    RD_T1 RS1_T1 RS2_X11 SLLIW        ; (value & 0x100000) << (31 - 20)
     RD_S7 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword
@@ -630,7 +630,7 @@
     ; First, calculate new shiftregister
     RD_T0 !0xFF ADDI
     RD_T0 RS1_S8 RS2_T0 AND           ; sr_nextb = shiftregister & 0xff
-    RD_S8 RS1_S8 RS2_X8 SRLI          ; shiftregister >> 8
+    RD_S8 RS1_S8 RS2_X8 SRLIW         ; shiftregister >> 8
 
     RD_T0 RS1_T0 RS2_A6 XOR           ; hex(c) ^ sr_nextb
     RD_T1 RS1_S5 RS2_X4 SLLI          ; hold << 4

--- a/riscv64/Development/hex2_riscv64.M1
+++ b/riscv64/Development/hex2_riscv64.M1
@@ -809,7 +809,7 @@
     RD_SP RS1_SP !-8 ADDI             ; Allocate stack
     RS1_SP RS2_RA SD                  ; protect ra
 
-    RD_A0 RS1_S9 MV                   ; strict entry
+    RD_A0 RS1_S9 MV                   ; struct entry
     RD_S9 RS1_S9 !24 ADDI             ; calloc
     RS1_A0 RS2_S6 @8 SD               ; entry->target = ip
     RS1_A0 RS2_S1 SD                  ; entry->next = jump_table

--- a/riscv64/Development/hex2_riscv64.hex2
+++ b/riscv64/Development/hex2_riscv64.hex2
@@ -379,22 +379,22 @@ F3 00              ## e_machine Indicating RISC-V
     ;        ((value >> 8) & 0xff00) |
     ;        ((value << 24) & 0xff000000))
 
-    93 53 85 01     # RD_T2 RS1_A0 RS2_X24 SRLI         ; value >> 24
+    9B 53 85 01     # RD_T2 RS1_A0 RS2_X24 SRLIW        ; value >> 24
     13 03 F0 0F     # RD_T1 !0xff ADDI                  ; t1 = 0xff
     B3 72 73 00     # RD_T0 RS1_T1 RS2_T2 AND           ; (value >> 24) & 0xff
 
-    93 13 85 00     # RD_T2 RS1_A0 RS2_X8 SLLI          ; value << 8
+    9B 13 85 00     # RD_T2 RS1_A0 RS2_X8 SLLIW         ; value << 8
     37 03 FF 00     # RD_T1 ~0xff0000 LUI               ; t1 = 0xff0000
     B3 73 73 00     # RD_T2 RS1_T1 RS2_T2 AND           ; (value << 8) & 0xff0000
     B3 E2 72 00     # RD_T0 RS1_T0 RS2_T2 OR            ; logical or with the previous expression
 
-    93 53 85 00     # RD_T2 RS1_A0 RS2_X8 SRLI          ; value >> 8
+    9B 53 85 00     # RD_T2 RS1_A0 RS2_X8 SRLIW         ; value >> 8
     37 03 01 00     # RD_T1 ~0xff00 LUI                 ; t1 = 0xff00
     1B 03 03 F0     # RD_T1 RS1_T1 !0xff00 ADDIW        ; t1 = 0xff00
     B3 73 73 00     # RD_T2 RS1_T1 RS2_T2 AND           ; (value << 8) & 0xff00
     B3 E2 72 00     # RD_T0 RS1_T0 RS2_T2 OR            ; logical or with the previous expression
 
-    93 13 85 01     # RD_T2 RS1_A0 RS2_X24 SLLI         ; value << 24
+    9B 13 85 01     # RD_T2 RS1_A0 RS2_X24 SLLIW        ; value << 24
     13 03 F0 0F     # RD_T1 !0xff ADDI
     13 13 83 01     # RD_T1 RS1_T1 RS2_X24 SLLI         ; t1 = 0xff000000
     B3 73 73 00     # RD_T2 RS1_T1 RS2_T2 AND           ; (value << 24) & 0xff000000
@@ -407,12 +407,12 @@ F3 00              ## e_machine Indicating RISC-V
 
 :UpdateShiftRegister_I
     ; Corresponds to RISC-V I format
-    13 05 45 00     # RD_A0 RS1_A0 !4 ADDI              ; add 4 due to this being 2nd part of AUIPC combo
+    1B 05 45 00     # RD_A0 RS1_A0 !4 ADDIW             ; add 4 due to this being 2nd part of AUIPC combo
 
     37 13 00 00     # RD_T1 ~0xfff LUI                  ; load higher bits
     1B 03 F3 FF     # RD_T1 RS1_T1 !0xfff ADDIW
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; (value & 0xfff)
-    93 1B 43 01     # RD_S7 RS1_T1 RS2_X20 SLLI         ; tempword = (value & 0xfff) << 20
+    9B 1B 43 01     # RD_S7 RS1_T1 RS2_X20 SLLIW        ; tempword = (value & 0xfff) << 20
     33 4C 7C 01     # RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword
 
     $Second_pass_loop 6F 00 00 00 # $Second_pass_loop JAL ; continue looping
@@ -427,22 +427,22 @@ F3 00              ## e_machine Indicating RISC-V
 
     13 03 E0 01     # RD_T1 !0x1e ADDI
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x1e
-    93 12 73 00     # RD_T0 RS1_T1 RS2_X7 SLLI          ; tempword = (value & 0x1e) << 7
+    9B 12 73 00     # RD_T0 RS1_T1 RS2_X7 SLLIW         ; tempword = (value & 0x1e) << 7
 
     13 03 00 7E     # RD_T1 !0x7e0 ADDI
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x7e0
-    13 13 43 01     # RD_T1 RS1_T1 RS2_X20 SLLI         ; (value & 0x7e0) << (31 - 11)
+    1B 13 43 01     # RD_T1 RS1_T1 RS2_X20 SLLIW        ; (value & 0x7e0) << (31 - 11)
     B3 E2 62 00     # RD_T0 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     37 13 00 00     # RD_T1 ~0x800 LUI                  ; load higher bits
     1B 03 03 80     # RD_T1 RS1_T1 !0x800 ADDIW
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x800
-    13 53 43 00     # RD_T1 RS1_T1 RS2_X4 SRLI          ; (value & 0x800) >> 4
+    1B 53 43 00     # RD_T1 RS1_T1 RS2_X4 SRLIW         ; (value & 0x800) >> 4
     B3 E2 62 00     # RD_T0 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     37 13 00 00     # RD_T1 ~0x1000 LUI                 ; load higher bits
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x1000
-    13 13 33 01     # RD_T1 RS1_T1 RS2_X19 SLLI         ; (value & 0x1000) << (31 - 12)
+    1B 13 33 01     # RD_T1 RS1_T1 RS2_X19 SLLIW        ; (value & 0x1000) << (31 - 12)
     B3 EB 62 00     # RD_S7 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     33 4C 7C 01     # RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword
@@ -459,12 +459,12 @@ F3 00              ## e_machine Indicating RISC-V
 
     13 03 E0 7F     # RD_T1 !0x7fe ADDI
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x7fe
-    93 12 43 01     # RD_T0 RS1_T1 RS2_X20 SLLI         ; tempword = (value & 0x7fe) << 20
+    9B 12 43 01     # RD_T0 RS1_T1 RS2_X20 SLLIW        ; tempword = (value & 0x7fe) << 20
 
     37 13 00 00     # RD_T1 ~0x800 LUI                  ; load higher bits
     1B 03 03 80     # RD_T1 RS1_T1 !0x800 ADDIW
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x800
-    13 13 93 00     # RD_T1 RS1_T1 RS2_X9 SLLI          ; (value & 0x800) << (20 - 11)
+    1B 13 93 00     # RD_T1 RS1_T1 RS2_X9 SLLIW         ; (value & 0x800) << (20 - 11)
     B3 E2 62 00     # RD_T0 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     37 F3 0F 00     # RD_T1 ~0xff000 LUI                ; load higher bits
@@ -473,7 +473,7 @@ F3 00              ## e_machine Indicating RISC-V
 
     37 03 10 00     # RD_T1 ~0x100000 LUI               ; load higher bits
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x100000
-    13 13 B3 00     # RD_T1 RS1_T1 RS2_X11 SLLI         ; (value & 0x100000) << (31 - 20)
+    1B 13 B3 00     # RD_T1 RS1_T1 RS2_X11 SLLIW        ; (value & 0x100000) << (31 - 20)
     B3 EB 62 00     # RD_S7 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     33 4C 7C 01     # RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword
@@ -675,7 +675,7 @@ F3 00              ## e_machine Indicating RISC-V
     ; First, calculate new shiftregister
     93 02 F0 0F     # RD_T0 !0xff ADDI
     B3 72 5C 00     # RD_T0 RS1_S8 RS2_T0 AND           ; sr_nextb = shiftregister & 0xff
-    13 5C 8C 00     # RD_S8 RS1_S8 RS2_X8 SRLI          ; shiftregister >> 8
+    1B 5C 8C 00     # RD_S8 RS1_S8 RS2_X8 SRLIW         ; shiftregister >> 8
 
     B3 C2 02 01     # RD_T0 RS1_T0 RS2_A6 XOR           ; hex(c) ^ sr_nextb
     13 93 4A 00     # RD_T1 RS1_S5 RS2_X4 SLLI          ; hold << 4

--- a/riscv64/Development/hex2_riscv64.hex2
+++ b/riscv64/Development/hex2_riscv64.hex2
@@ -854,7 +854,7 @@ F3 00              ## e_machine Indicating RISC-V
     13 01 81 FF     # RD_SP RS1_SP !-8 ADDI             ; Allocate stack
     23 30 11 00     # RS1_SP RS2_RA SD                  ; protect ra
 
-    13 85 0C 00     # RD_A0 RS1_S9 MV                   ; strict entry
+    13 85 0C 00     # RD_A0 RS1_S9 MV                   ; struct entry
     93 8C 8C 01     # RD_S9 RS1_S9 !24 ADDI             ; calloc
     23 34 65 01     # RS1_A0 RS2_S6 @8 SD               ; entry->target = ip
     23 30 95 00     # RS1_A0 RS2_S1 SD                  ; entry->next = jump_table

--- a/riscv64/GAS/M0_riscv64.S
+++ b/riscv64/GAS/M0_riscv64.S
@@ -25,6 +25,7 @@
 # s3: output fd
 # s4: struct HEAD
 # s5: protected char
+# s6: scratch
 
 # Struct format: (size 32)
 # NEXT => 0                           # Next element in linked list
@@ -80,6 +81,10 @@ after_open:
     mv a0, zero                       # Get current brk
     ecall                             # syscall
     mv s1, a0                         # Set our malloc pointer
+
+    li a0, 512                        # Allocate scratch
+    jal malloc                        # Get S pointer
+    mv s6, a0                         # Save scratch pointer
 
     jal Tokenize_Line                 # Get all lines
     mv a0, s4                         # Prepare for Reverse_List
@@ -191,11 +196,8 @@ Store_String:
 
     li a0, 2                          # Using TYPE STRING
     sd a0, 8(a3)                      # HEAD->TYPE = STRING
-    la a0, 256                        # Malloc the string
-    jal malloc                        # Get pointer to P
-    sd a0, 16(a3)                     # HEAD->TEXT = STRING
     mv a1, a2                         # Protect terminator
-    mv a3, a0                         # Protect string pointer
+    mv a3, s6                         # Protect string pointer
 Store_String_Loop:
     sb a2, 0(a3)                      # write byte
     jal fgetc                         # read next char
@@ -203,11 +205,71 @@ Store_String_Loop:
     addi a3, a3, 1                    # STRING = STRING + 1
     bne a1, a2, Store_String_Loop     # Keep looping unless we hit terminator
 
+    mv a0, s6                         # Prepare the string in scratch
+    jal string_length                 # Calculate length
+    addi a0, a0, 1                    # Add 1 for 0 terminator
+    jal malloc                        # Allocate memory
+    ld a3, 16(sp)                     # restore a3 (HEAD)
+    sd a0, 16(a3)                     # HEAD->TEXT = STRING
+    jal copy_string                   # Copy the string
+
     ld a1, 0(sp)                      # restore a1
     ld a2, 8(sp)                      # restore a2
-    ld a3, 16(sp)                     # restore a3
     addi sp, sp, 24                   # deallocate stack
     j restart
+
+
+# copy_string function
+# Receives target in a0, and scratch s6 for source
+# Uses a0, for target string T, a1 for C, a2 for source string S
+# Returns nothing
+copy_string:
+    addi sp, sp, -24                  # allocate stack
+    sd ra, 0(sp)                      # protect ra
+    sd a1, 8(sp)                      # protect a1
+    sd a2, 16(sp)                     # protect a2
+
+    mv a2, s6                         # Get S
+
+copy_string_loop:
+    lbu a1, (a2)                      # S[0]
+    beqz a1, copy_string_done         # Check if we are done
+
+    sb a1, (a0)                       # Copy char
+    addi a2, a2, 1                    # S = S + 1
+    addi a0, a0, 1                    # T = T + 1
+    j copy_string_loop                # Keep going
+
+copy_string_done:
+    jal ClearScratch                  # Clear scratch
+
+    ld ra, 0(sp)                      # restore ra
+    ld a1, 8(sp)                      # restore a1
+    ld a2, 16(sp)                     # restore a2
+    addi sp, sp, 24                   # deallocate stack
+    ret
+
+
+# Zero scratch area
+ClearScratch:
+    addi sp, sp, -24                  # allocate stack
+    sd ra, 0(sp)                      # protect ra
+    sd a0, 8(sp)                      # protect a0
+    sd a1, 16(sp)                     # protect a1
+
+    mv a0, s6                         # Prepare scratch
+
+ClearScratch_loop:
+    lb a1, (a0)                       # Read current byte: s[i]
+    sb zero, (a0)                     # Write zero: s[i] = 0
+    addi a0, a0, 1                    # Increment: i = i + 1
+    bnez a1, ClearScratch_loop        # Keep looping
+
+    ld ra, 0(sp)                      # restore ra
+    ld a0, 8(sp)                      # restore a0
+    ld a1, 16(sp)                     # restore a1
+    addi sp, sp, 24                   # deallocate stack
+    ret                               # return
 
 
 # Store_Atom Function
@@ -220,11 +282,8 @@ Store_Atom:
     sd a2, 16(sp)                     # protect a2
     sd a3, 24(sp)                     # protect a3
 
-    li a0, 256                        # Malloc the string
-    jal malloc                        # Get pointer to P
-    sd a0, 16(a3)                     # HEAD->TEXT = STRING
     la a1, terminators                # Get pointer to "\n\t "
-    mv a3, a0                         # Protect string pointer
+    mv a3, s6                         # Protect string pointer
 
 Store_Atom_loop:
     sb a2, 0(a3)                      # write byte
@@ -234,10 +293,18 @@ Store_Atom_loop:
     jal In_Set                        # Check for terminators
     beqz a0, Store_Atom_loop          # Loop if not "\n\t "
 
+    mv a0, s6                         # Prepare the string in scratch
+    jal string_length                 # Calculate length
+    addi a0, a0, 1                    # Add 1 for 0 terminator
+    jal malloc                        # Allocate memory
+    ld a3, 24(sp)                     # restore a3 (HEAD)
+    sd a0, 16(a3)                     # HEAD->TEXT = STRING
+    jal copy_string                   # Copy the string
+
+    mv a0, a3                         # Return HEAD
     ld ra, 0(sp)                      # restore ra
     ld a1, 8(sp)                      # restore a1
     ld a2, 16(sp)                     # restore a2
-    ld a3, 24(sp)                     # restore a3
     addi sp, sp, 32                   # deallocate stack
     ret                               # return
 

--- a/riscv64/GAS/hex2_riscv64.S
+++ b/riscv64/GAS/hex2_riscv64.S
@@ -328,21 +328,21 @@ UpdateShiftRegister_DOT:
     #        ((value >> 8) & 0xff00) |
     #        ((value << 24) & 0xff000000))
 
-    srli t2, a0, 24              # value >> 24
+    srliw t2, a0, 24             # value >> 24
     li t1, 0xff                  # t1 = 0xff
     and t0, t1, t2               # (value >> 24) & 0xff
 
-    slli t2, a0, 8               # value << 8
+    slliw t2, a0, 8              # value << 8
     li t1, 0xff0000              # t1 = 0xff0000
     and t2, t1, t2               # (value << 8) & 0xff0000
     or t0, t0, t2                # logical or with the previous expression
 
-    srli t2, a0, 8               # value >> 8
+    srliw t2, a0, 8              # value >> 8
     li t1, 0xff00                # t1 = 0xff00
     and t2, t1, t2               # (value >> 8) & 0xff00
     or t0, t0, t2                # logical or with the previous expression
 
-    slli t2, a0, 24              # value << 24
+    slliw t2, a0, 24             # value << 24
     li t1, 0xff000000            # t1 = 0xff000000
     and t2, t1, t2               # (value << 24) & 0xff000000
     or t0, t0, t2                # swap
@@ -354,11 +354,11 @@ UpdateShiftRegister_DOT:
 
 UpdateShiftRegister_I:
     # Corresponds to RISC-V I format
-    addi a0, a0, 4               # add 4 due to this being 2nd part of AUIPC combo
+    addiw a0, a0, 4              # add 4 due to this being 2nd part of AUIPC combo
 
     li t1, 0xfff
     and t1, a0, t1               # (value & 0xfff)
-    slli s7, t1, 20              # tempword = (value & 0xfff) << 20
+    slliw s7, t1, 20             # tempword = (value & 0xfff) << 20
     xor s8, s8, s7               # shiftregister = shiftregister ^ tempword
 
     j Second_pass_loop           # Continue looping
@@ -373,21 +373,21 @@ UpdateShiftRegister_B:
 
     li t1, 0x1e
     and t1, a0, t1               # value & 0x1e
-    slli t0, t1, 7               # tempword = (value & 0x1e) << 7
+    slliw t0, t1, 7              # tempword = (value & 0x1e) << 7
 
     li t1, 0x7e0
     and t1, a0, t1               # value & 0x7e0
-    slli t1, t1, 20              # (value & 0x7e0) << (31 - 11)
+    slliw t1, t1, 20             # (value & 0x7e0) << (31 - 11)
     or t0, t0, t1                # logical or with the previous expression
 
     li t1, 0x800
     and t1, a0, t1               # value & 0x800
-    srli t1, t1, 4               # (value & 0x800) >> 4
+    srliw t1, t1, 4              # (value & 0x800) >> 4
     or t0, t0, t1                # logical or with the previous expression
 
     li t1, 0x1000
     and t1, a0, t1               # value & 0x1000
-    slli t1, t1, 19              # (value & 0x1000) << (31 - 12)
+    slliw t1, t1, 19             # (value & 0x1000) << (31 - 12)
     or s7, t0, t1                # tempword
 
     xor s8, s8, s7               # shiftregister = shiftregister ^ tempword
@@ -404,11 +404,11 @@ UpdateShiftRegister_J:
 
     li t1, 0x7fe
     and t1, a0, t1               # value & 0x7fe
-    slli t0, t1, 20              # tempword = (value & 0x7fe) << 20
+    slliw t0, t1, 20             # tempword = (value & 0x7fe) << 20
 
     li t1, 0x800
     and t1, a0, t1               # value & 0x800
-    slli t1, t1, 9               # (value & 0x800) << (20 - 11)
+    slliw t1, t1, 9              # (value & 0x800) << (20 - 11)
     or t0, t0, t1                # logical or with the previous expression
 
     li t1, 0xff000
@@ -417,7 +417,7 @@ UpdateShiftRegister_J:
 
     li t1, 0x100000
     and t1, a0, t1               # value & 0x100000
-    slli t1, t1, 11              # (value & 0x100000) << (31 - 20)
+    slliw t1, t1, 11             # (value & 0x100000) << (31 - 20)
     or s7, t0, t1                # tempword
 
     xor s8, s8, s7               # shiftregister = shiftregister ^ tempword
@@ -610,7 +610,7 @@ DoByte:
     # First, calculate new shiftregister
     li t0, 0xff
     and t0, s8, t0               # sr_nextb = shiftregister & 0xff
-    srli s8, s8, 8               # shiftregister >> 8
+    srliw s8, s8, 8              # shiftregister >> 8
 
     xor t0, t0, a6               # hex(c) ^ sr_nextb
     slli t1, s5, 4               # hold * 16

--- a/riscv64/M0_riscv64.hex2
+++ b/riscv64/M0_riscv64.hex2
@@ -25,6 +25,7 @@
 ; s3: output fd
 ; s4: struct HEAD
 ; s5: protected char
+; s6: scratch
 
 ; Struct format: (size 32)
 ; NEXT => 0                           ; Next element in linked list
@@ -101,6 +102,13 @@
     73000000
     # RD_S1 RS1_A0 MV                   ; Set our malloc pointer
     .80040000 .00000500 13000000
+
+    # RD_A0 !512 ADDI                   ; Allocate scratch
+    .00050000 .00000020 13000000
+    # RD_RA $malloc JAL                 ; Get S pointer
+    .80000000 $malloc 6F000000
+    # RD_S6 RS1_A0 MV                   ; Save scratch pointer
+    .000B0000 .00000500 13000000
 
     # RD_RA $Tokenize_Line JAL          ; Get all lines
     .80000000 $Tokenize_Line 6F000000
@@ -287,16 +295,10 @@
     .00050000 .00002000 13000000
     # RS1_A3 RS2_A0 @8 SD               ; HEAD->TYPE = STRING
     .00800600 .0000A000 .00040000 23300000
-    # RD_A0 !256 ADDI                   ; Malloc the string
-    .00050000 .00000010 13000000
-    # RD_RA $malloc JAL                 ; Get pointer to P
-    .80000000 $malloc 6F000000
-    # RS1_A3 RS2_A0 @16 SD              ; HEAD->TEXT = STRING
-    .00800600 .0000A000 .00080000 23300000
     # RD_A1 RS1_A2 MV                   ; Protect terminator
     .80050000 .00000600 13000000
-    # RD_A3 RS1_A0 MV                   ; Protect string pointer
-    .80060000 .00000500 13000000
+    # RD_A3 RS1_S6 MV                   ; Protect string pointer
+    .80060000 .00000B00 13000000
 :Store_String_Loop
     # RS1_A3 RS2_A2 SB                  ; write byte
     .00800600 .0000C000 23000000
@@ -309,16 +311,112 @@
     # RS1_A1 RS2_A2 @Store_String_Loop BNE ; Keep looping unless we hit terminator
     .00800500 .0000C000 @Store_String_Loop 63100000
 
+    # RD_A0 RS1_S6 MV                   ; Prepare the string in scratch
+    .00050000 .00000B00 13000000
+    # RD_RA $string_length JAL          ; Calculate length
+    .80000000 $string_length 6F000000
+    # RD_A0 RS1_A0 !1 ADDI              ; Add 1 for 0 terminator
+    .00050000 .00000500 .00001000 13000000
+    # RD_RA $malloc JAL                 ; Allocate memory
+    .80000000 $malloc 6F000000
+    # RD_A3 RS1_SP !16 LD               ; restore a3 (HEAD)
+    .80060000 .00000100 .00000001 03300000
+    # RS1_A3 RS2_A0 @16 SD              ; HEAD->TEXT = STRING
+    .00800600 .0000A000 .00080000 23300000
+    # RD_RA $copy_string JAL            ; Copy the string
+    .80000000 $copy_string 6F000000
+
     # RD_A1 RS1_SP LD                   ; restore a1
     .80050000 .00000100 03300000
     # RD_A2 RS1_SP !8 LD                ; restore a2
     .00060000 .00000100 .00008000 03300000
-    # RD_A3 RS1_SP !16 LD               ; restore a3
-    .80060000 .00000100 .00000001 03300000
     # RD_SP RS1_SP !24 ADDI             ; deallocate stack
     .00010000 .00000100 .00008001 13000000
     # $restart JAL
     $restart 6F000000
+
+; copy_string function
+; Receives target in a0, and scratch s6 for source
+; Uses a0, for target string T, a1 for C, a2 for source string S
+; Returns nothing
+:copy_string
+    # RD_SP RS1_SP !-24 ADDI            ; allocate stack
+    .00010000 .00000100 .000080FE 13000000
+    # RS1_SP RS2_RA SD                  ; protect ra
+    .00000100 .00001000 23300000
+    # RS1_SP RS2_A1 @8 SD               ; protect a1
+    .00000100 .0000B000 .00040000 23300000
+    # RS1_SP RS2_A2 @16 SD              ; protect a2
+    .00000100 .0000C000 .00080000 23300000
+
+    # RD_A2 RS1_S6 MV                   ; Get S
+    .00060000 .00000B00 13000000
+
+:copy_string_loop
+    # RD_A1 RS1_A2 LBU                  ; S[0]
+    .80050000 .00000600 03400000
+    # RS1_A1 @copy_string_done BEQZ     ; Check if we are done
+    .00800500 @copy_string_done 63000000
+
+    # RS1_A0 RS2_A1 SB                  ; Copy char
+    .00000500 .0000B000 23000000
+    # RD_A2 RS1_A2 !1 ADDI              ; S = S + 1
+    .00060000 .00000600 .00001000 13000000
+    # RD_A0 RS1_A0 !1 ADDI              ; T = T + 1
+    .00050000 .00000500 .00001000 13000000
+    # $copy_string_loop JAL             ; Keep going
+    $copy_string_loop 6F000000
+
+:copy_string_done
+    # RD_RA $ClearScratch JAL           ; Clear scratch
+    .80000000 $ClearScratch 6F000000
+
+    # RD_RA RS1_SP LD                   ; restore ra
+    .80000000 .00000100 03300000
+    # RD_A1 RS1_SP !8 LD                ; restore a1
+    .80050000 .00000100 .00008000 03300000
+    # RD_A2 RS1_SP !16 LD               ; restore a2
+    .00060000 .00000100 .00000001 03300000
+    # RD_SP RS1_SP !24 ADDI             ; deallocate stack
+    .00010000 .00000100 .00008001 13000000
+    # RETURN
+    67800000
+
+
+; Zero scratch area
+:ClearScratch
+    # RD_SP RS1_SP !-24 ADDI            ; allocate stack
+    .00010000 .00000100 .000080FE 13000000
+    # RS1_SP RS2_RA SD                  ; protect ra
+    .00000100 .00001000 23300000
+    # RS1_SP RS2_A0 @8 SD               ; protect a0
+    .00000100 .0000A000 .00040000 23300000
+    # RS1_SP RS2_A1 @16 SD              ; protect a1
+    .00000100 .0000B000 .00080000 23300000
+
+    # RD_A0 RS1_S6 MV                   ; Prepare scratch
+    .00050000 .00000B00 13000000
+
+:ClearScratch_loop
+    # RD_A1 RS1_A0 LB                   ; Read current byte: s[i]
+    .80050000 .00000500 03000000
+    # RS1_A0 SB                         ; Write zero: s[i] = 0
+    .00000500 23000000
+    # RD_A0 RS1_A0 !1 ADDI              ; Increment: i = i + 1
+    .00050000 .00000500 .00001000 13000000
+    # RS1_A1 @ClearScratch_loop BNEZ    ; Keep looping
+    .00800500 @ClearScratch_loop 63100000
+
+    # RD_RA RS1_SP LD                   ; restore ra
+    .80000000 .00000100 03300000
+    # RD_A0 RS1_SP !8 LD                ; restore a0
+    .00050000 .00000100 .00008000 03300000
+    # RD_A1 RS1_SP !16 LD               ; restore a1
+    .80050000 .00000100 .00000001 03300000
+    # RD_SP RS1_SP !24 ADDI             ; deallocate stack
+    .00010000 .00000100 .00008001 13000000
+    # RETURN
+    67800000
 
 
 ; Store_Atom Function
@@ -336,18 +434,12 @@
     # RS1_SP RS2_A3 @24 SD              ; protect a3
     .00000100 .0000D000 .000C0000 23300000
 
-    # RD_A0 !256 ADDI                   ; Malloc the string
-    .00050000 .00000010 13000000
-    # RD_RA $malloc JAL                 ; Get pointer to P
-    .80000000 $malloc 6F000000
-    # RS1_A3 RS2_A0 @16 SD              ; HEAD->TEXT = STRING
-    .00800600 .0000A000 .00080000 23300000
     # RD_A1 ~terminators AUIPC          ; Get pointer to "\n\t "
     .80050000 ~terminators 17000000
     # RD_A1 RS1_A1 !terminators ADDI    ; Get pointer to "\n\t "
     .80050000 .00800500 !terminators 13000000
-    # RD_A3 RS1_A0 MV                   ; Protect string pointer
-    .80060000 .00000500 13000000
+    # RD_A3 RS1_S6 MV                   ; Protect string pointer
+    .80060000 .00000B00 13000000
 
 :Store_Atom_loop
     # RS1_A3 RS2_A2 SB                  ; write byte
@@ -363,14 +455,27 @@
     # RS1_A0 @Store_Atom_loop BEQZ      ; Loop if not "\n\t "
     .00000500 @Store_Atom_loop 63000000
 
+    # RD_A0 RS1_S6 MV                   ; Prepare the string in scratch
+    .00050000 .00000B00 13000000
+    # RD_RA $string_length JAL          ; Calculate length
+    .80000000 $string_length 6F000000
+    # RD_A0 RS1_A0 !1 ADDI              ; Add 1 for 0 terminator
+    .00050000 .00000500 .00001000 13000000
+    # RD_RA $malloc JAL                 ; Allocate memory
+    .80000000 $malloc 6F000000
+    # RD_A3 RS1_SP !24 LD               ; restore a3
+    .80060000 .00000100 .00008001 03300000
+    # RS1_A3 RS2_A0 @16 SD              ; HEAD->TEXT = STRING
+    .00800600 .0000A000 .00080000 23300000
+    # RD_RA $copy_string JAL            ; Copy the string
+    .80000000 $copy_string 6F000000
+
     # RD_RA RS1_SP LD                   ; restore ra
     .80000000 .00000100 03300000
     # RD_A1 RS1_SP !8 LD                ; restore a1
     .80050000 .00000100 .00008000 03300000
     # RD_A2 RS1_SP !16 LD               ; restore a2
     .00060000 .00000100 .00000001 03300000
-    # RD_A3 RS1_SP !24 LD               ; restore a3
-    .80060000 .00000100 .00008001 03300000
     # RD_SP RS1_SP !32 ADDI             ; deallocate stack
     .00010000 .00000100 .00000002 13000000
     # RS1_RA JALR                       ; return

--- a/riscv64/cc_riscv64.M1
+++ b/riscv64/cc_riscv64.M1
@@ -3178,7 +3178,7 @@
 
     RD_A0 ~additive_expr AUIPC        ; Using additive_expr
     RD_A0 RS1_A0 !additive_expr ADDI
-    RD_A1 ~relational_expr_stub_string_0 AUIPC ; Using "RD_T0 MV\nRS1_A1 RS2_A0 @8 BGE\nRD_T0 !1 ADDI\nRD_A0 RS1_T0 MV\n"
+    RD_A1 ~relational_expr_stub_string_0 AUIPC ; Using "RD_A0 RS1_A1 RS2_A0 SLT\n"
     RD_A1 RS1_A1 !relational_expr_stub_string_0 ADDI
     RD_A2 ~less_than_string AUIPC     ; Using "<"
     RD_A2 RS1_A2 !less_than_string ADDI
@@ -3188,7 +3188,7 @@
 
     RD_A0 ~additive_expr AUIPC        ; Using additive_expr
     RD_A0 RS1_A0 !additive_expr ADDI
-    RD_A1 ~relational_expr_stub_string_1 AUIPC ; Using "RD_T0 MV\nRS1_A0 RS2_A1 @8 BLT\nRD_T0 !1 ADDI\nRD_A0 RS1_T0 MV\n"
+    RD_A1 ~relational_expr_stub_string_1 AUIPC ; Using "RD_A0 RS1_A0 !1 ADDI\nRD_A0 RS1_A1 RS2_A0 SLT\n"
     RD_A1 RS1_A1 !relational_expr_stub_string_1 ADDI
     RD_A2 ~less_than_equal_string AUIPC ; Using "<="
     RD_A2 RS1_A2 !less_than_equal_string ADDI
@@ -3198,7 +3198,7 @@
 
     RD_A0 ~additive_expr AUIPC        ; Using additive_expr
     RD_A0 RS1_A0 !additive_expr ADDI
-    RD_A1 ~relational_expr_stub_string_2 AUIPC ; Using "RD_T0 MV\nRS1_A1 RS2_A0 @8 BLT\nRD_T0 !1 ADDI\nRD_A0 RS1_T0 MV\n"
+    RD_A1 ~relational_expr_stub_string_2 AUIPC ; Using "RD_A0 RS1_A0 !-1 ADDI\nRD_A0 RS1_A0 RS2_A1 SLT\n"
     RD_A1 RS1_A1 !relational_expr_stub_string_2 ADDI
     RD_A2 ~greater_than_equal_string AUIPC ; Using ">="
     RD_A2 RS1_A2 !greater_than_equal_string ADDI
@@ -3208,7 +3208,7 @@
 
     RD_A0 ~additive_expr AUIPC        ; Using additive_expr
     RD_A0 RS1_A0 !additive_expr ADDI
-    RD_A1 ~relational_expr_stub_string_3 AUIPC ; Using "RD_T0 MV\nRS1_A0 RS2_A1 @8 BGE\nRD_T0 !1 ADDI\nRD_A0 RS1_T0 MV\n"
+    RD_A1 ~relational_expr_stub_string_3 AUIPC ; Using "RD_A0 RS1_A0 RS2_A1 SLT\n"
     RD_A1 RS1_A1 !relational_expr_stub_string_3 ADDI
     RD_A2 ~greater_than_string AUIPC  ; Using ">"
     RD_A2 RS1_A2 !greater_than_string ADDI
@@ -3218,7 +3218,7 @@
 
     RD_A0 ~additive_expr AUIPC        ; Using additive_expr
     RD_A0 RS1_A0 !additive_expr ADDI
-    RD_A1 ~relational_expr_stub_string_4 AUIPC ; Using "RD_T0 MV\nRS1_A1 RS2_A0 @8 BNE\nRD_T0 !1 ADDI\nRD_A0 RS1_T0 MV\n"
+    RD_A1 ~relational_expr_stub_string_4 AUIPC ; Using "RD_A0 RS1_A0 RS2_A1 SUB\nRD_A0 RS1_A0 !1 SLTIU\n"
     RD_A1 RS1_A1 !relational_expr_stub_string_4 ADDI
     RD_A2 ~equal_to_string AUIPC      ; Using "=="
     RD_A2 RS1_A2 !equal_to_string ADDI
@@ -3228,7 +3228,7 @@
 
     RD_A0 ~additive_expr AUIPC        ; Using additive_expr
     RD_A0 RS1_A0 !additive_expr ADDI
-    RD_A1 ~relational_expr_stub_string_5 AUIPC ; Using "RD_T0 MV\nRS1_A1 RS2_A0 @8 BEQ\nRD_T0 !1 ADDI\nRD_A0 RS1_T0 MV\n"
+    RD_A1 ~relational_expr_stub_string_5 AUIPC ; Using "RD_A0 RS1_A0 RS2_A1 SUB\nRD_A0 RS2_A0 SLTU\n"
     RD_A1 RS1_A1 !relational_expr_stub_string_5 ADDI
     RD_A2 ~not_equal_string AUIPC     ; Using "!="
     RD_A2 RS1_A2 !not_equal_string ADDI
@@ -5115,6 +5115,11 @@ MISSING ;
 MISSING (
 "
 
+# Here @8 means jump 8 bytes forward, hence we skip one instruction.
+# This slightly abuses M1 encoding since M1 uses @ for S-type instructions
+# but we need B-type instruction. Fortunately, B and S encodings are
+# identical for values up to 2047.
+
 :process_while_string_3
 "RS1_A0 @8 BNEZ
 $END_WHILE_"
@@ -5353,41 +5358,25 @@ RD_A0 RS1_A0 !STRING_"
 :bitwise_expr_stub_string_2  "RD_A0 RS1_A1 RS2_A0 XOR
 "
 
-# Here @8 means jump 8 bytes forward, hence we skip one instruction.
-# This slightly abuses M1 encoding since M1 uses @ for S-type instructions
-# but we need B-type instruction. Fortunately, B and S encodings are
-# identical for values up to 2047.
-:relational_expr_stub_string_0  "RD_T0 MV
-RS1_A1 RS2_A0 @8 BGE
-RD_T0 !1 ADDI
-RD_A0 RS1_T0 MV
+:relational_expr_stub_string_0  "RD_A0 RS1_A1 RS2_A0 SLT
 "
 
-:relational_expr_stub_string_1  "RD_T0 MV
-RS1_A0 RS2_A1 @8 BLT
-RD_T0 !1 ADDI
-RD_A0 RS1_T0 MV
+:relational_expr_stub_string_1  "RD_A0 RS1_A0 !1 ADDI
+RD_A0 RS1_A1 RS2_A0 SLT
 "
-:relational_expr_stub_string_2  "RD_T0 MV
-RS1_A1 RS2_A0 @8 BLT
-RD_T0 !1 ADDI
-RD_A0 RS1_T0 MV
-"
-:relational_expr_stub_string_3  "RD_T0 MV
-RS1_A0 RS2_A1 @8 BGE
-RD_T0 !1 ADDI
-RD_A0 RS1_T0 MV
 
+:relational_expr_stub_string_2  "RD_A0 RS1_A0 !-1 ADDI
+RD_A0 RS1_A0 RS2_A1 SLT
 "
-:relational_expr_stub_string_4  "RD_T0 MV
-RS1_A1 RS2_A0 @8 BNE
-RD_T0 !1 ADDI
-RD_A0 RS1_T0 MV
+
+:relational_expr_stub_string_3  "RD_A0 RS1_A0 RS2_A1 SLT
 "
-:relational_expr_stub_string_5  "RD_T0 MV
-RS1_A1 RS2_A0 @8 BEQ
-RD_T0 !1 ADDI
-RD_A0 RS1_T0 MV
+
+:relational_expr_stub_string_4  "RD_A0 RS1_A0 RS2_A1 SUB
+RD_A0 RS1_A0 !1 SLTIU
+"
+:relational_expr_stub_string_5  "RD_A0 RS1_A0 RS2_A1 SUB
+RD_A0 RS2_A0 SLTU
 "
 
 :additive_expr_stub_string_0  "RD_A0 RS1_A1 RS2_A0 ADD

--- a/riscv64/cc_riscv64.M1
+++ b/riscv64/cc_riscv64.M1
@@ -5461,7 +5461,7 @@ RD_A0 RS1_A1 RS2_A0 ADD
 "
 
 :global_load_string_0
-"RD_A0 ~GLOBAL_"RR
+"RD_A0 ~GLOBAL_"
 
 :global_load_string_1
 " AUIPC

--- a/riscv64/hex2_riscv64.hex1
+++ b/riscv64/hex2_riscv64.hex1
@@ -854,7 +854,7 @@ FC 07 00 00 00 00 00 00 ## p_memsz
     13 01 81 FF     # RD_SP RS1_SP !-8 ADDI             ; Allocate stack
     23 30 11 00     # RS1_SP RS2_RA SD                  ; protect ra
 
-    13 85 0C 00     # RD_A0 RS1_S9 MV                   ; strict entry
+    13 85 0C 00     # RD_A0 RS1_S9 MV                   ; struct entry
     93 8C 8C 01     # RD_S9 RS1_S9 !24 ADDI             ; calloc
     23 34 65 01     # RS1_A0 RS2_S6 @8 SD               ; entry->target = ip
     23 30 95 00     # RS1_A0 RS2_S1 SD                  ; entry->next = jump_table

--- a/riscv64/hex2_riscv64.hex1
+++ b/riscv64/hex2_riscv64.hex1
@@ -379,22 +379,22 @@ FC 07 00 00 00 00 00 00 ## p_memsz
     ;        ((value >> 8) & 0xff00) |
     ;        ((value << 24) & 0xff000000))
 
-    93 53 85 01     # RD_T2 RS1_A0 RS2_X24 SRLI         ; value >> 24
+    9B 53 85 01     # RD_T2 RS1_A0 RS2_X24 SRLIW        ; value >> 24
     13 03 F0 0F     # RD_T1 !0xff ADDI                  ; t1 = 0xff
     B3 72 73 00     # RD_T0 RS1_T1 RS2_T2 AND           ; (value >> 24) & 0xff
 
-    93 13 85 00     # RD_T2 RS1_A0 RS2_X8 SLLI          ; value << 8
+    9B 13 85 00     # RD_T2 RS1_A0 RS2_X8 SLLIW         ; value << 8
     37 03 FF 00     # RD_T1 ~0xff0000 LUI               ; t1 = 0xff0000
     B3 73 73 00     # RD_T2 RS1_T1 RS2_T2 AND           ; (value << 8) & 0xff0000
     B3 E2 72 00     # RD_T0 RS1_T0 RS2_T2 OR            ; logical or with the previous expression
 
-    93 53 85 00     # RD_T2 RS1_A0 RS2_X8 SRLI          ; value >> 8
+    9B 53 85 00     # RD_T2 RS1_A0 RS2_X8 SRLIW         ; value >> 8
     37 03 01 00     # RD_T1 ~0xff00 LUI                 ; t1 = 0xff00
     1B 03 03 F0     # RD_T1 RS1_T1 !0xff00 ADDIW        ; t1 = 0xff00
     B3 73 73 00     # RD_T2 RS1_T1 RS2_T2 AND           ; (value << 8) & 0xff00
     B3 E2 72 00     # RD_T0 RS1_T0 RS2_T2 OR            ; logical or with the previous expression
 
-    93 13 85 01     # RD_T2 RS1_A0 RS2_X24 SLLI         ; value << 24
+    9B 13 85 01     # RD_T2 RS1_A0 RS2_X24 SLLIW        ; value << 24
     13 03 F0 0F     # RD_T1 !0xff ADDI
     13 13 83 01     # RD_T1 RS1_T1 RS2_X24 SLLI         ; t1 = 0xff000000
     B3 73 73 00     # RD_T2 RS1_T1 RS2_T2 AND           ; (value << 24) & 0xff000000
@@ -407,12 +407,12 @@ FC 07 00 00 00 00 00 00 ## p_memsz
 
 :I ;UpdateShiftRegister_I
     ; Corresponds to RISC-V I format
-    13 05 45 00     # RD_A0 RS1_A0 !4 ADDI              ; add 4 due to this being 2nd part of AUIPC combo
+    1B 05 45 00     # RD_A0 RS1_A0 !4 ADDIW             ; add 4 due to this being 2nd part of AUIPC combo
 
     37 13 00 00     # RD_T1 ~0xfff LUI                  ; load higher bits
     1B 03 F3 FF     # RD_T1 RS1_T1 !0xfff ADDIW
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; (value & 0xfff)
-    93 1B 43 01     # RD_S7 RS1_T1 RS2_X20 SLLI         ; tempword = (value & 0xfff) << 20
+    9B 1B 43 01     # RD_S7 RS1_T1 RS2_X20 SLLIW        ; tempword = (value & 0xfff) << 20
     33 4C 7C 01     # RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword
 
     $5 6F 00 00 00  # $Second_pass_loop JAL             ; continue looping
@@ -427,22 +427,22 @@ FC 07 00 00 00 00 00 00 ## p_memsz
 
     13 03 E0 01     # RD_T1 !0x1e ADDI
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x1e
-    93 12 73 00     # RD_T0 RS1_T1 RS2_X7 SLLI          ; tempword = (value & 0x1e) << 7
+    9B 12 73 00     # RD_T0 RS1_T1 RS2_X7 SLLIW         ; tempword = (value & 0x1e) << 7
 
     13 03 00 7E     # RD_T1 !0x7e0 ADDI
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x7e0
-    13 13 43 01     # RD_T1 RS1_T1 RS2_X20 SLLI         ; (value & 0x7e0) << (31 - 11)
+    1B 13 43 01     # RD_T1 RS1_T1 RS2_X20 SLLIW        ; (value & 0x7e0) << (31 - 11)
     B3 E2 62 00     # RD_T0 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     37 13 00 00     # RD_T1 ~0x800 LUI                  ; load higher bits
     1B 03 03 80     # RD_T1 RS1_T1 !0x800 ADDIW
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x800
-    13 53 43 00     # RD_T1 RS1_T1 RS2_X4 SRLI          ; (value & 0x800) >> 4
+    1B 53 43 00     # RD_T1 RS1_T1 RS2_X4 SRLIW         ; (value & 0x800) >> 4
     B3 E2 62 00     # RD_T0 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     37 13 00 00     # RD_T1 ~0x1000 LUI                 ; load higher bits
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x1000
-    13 13 33 01     # RD_T1 RS1_T1 RS2_X19 SLLI         ; (value & 0x1000) << (31 - 12)
+    1B 13 33 01     # RD_T1 RS1_T1 RS2_X19 SLLIW        ; (value & 0x1000) << (31 - 12)
     B3 EB 62 00     # RD_S7 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     33 4C 7C 01     # RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword
@@ -459,12 +459,12 @@ FC 07 00 00 00 00 00 00 ## p_memsz
 
     13 03 E0 7F     # RD_T1 !0x7fe ADDI
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x7fe
-    93 12 43 01     # RD_T0 RS1_T1 RS2_X20 SLLI         ; tempword = (value & 0x7fe) << 20
+    9B 12 43 01     # RD_T0 RS1_T1 RS2_X20 SLLIW        ; tempword = (value & 0x7fe) << 20
 
     37 13 00 00     # RD_T1 ~0x800 LUI                  ; load higher bits
     1B 03 03 80     # RD_T1 RS1_T1 !0x800 ADDIW
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x800
-    13 13 93 00     # RD_T1 RS1_T1 RS2_X9 SLLI          ; (value & 0x800) << (20 - 11)
+    1B 13 93 00     # RD_T1 RS1_T1 RS2_X9 SLLIW         ; (value & 0x800) << (20 - 11)
     B3 E2 62 00     # RD_T0 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     37 F3 0F 00     # RD_T1 ~0xff000 LUI                ; load higher bits
@@ -473,7 +473,7 @@ FC 07 00 00 00 00 00 00 ## p_memsz
 
     37 03 10 00     # RD_T1 ~0x100000 LUI               ; load higher bits
     33 73 65 00     # RD_T1 RS1_A0 RS2_T1 AND           ; value & 0x100000
-    13 13 B3 00     # RD_T1 RS1_T1 RS2_X11 SLLI         ; (value & 0x100000) << (31 - 20)
+    1B 13 B3 00     # RD_T1 RS1_T1 RS2_X11 SLLIW        ; (value & 0x100000) << (31 - 20)
     B3 EB 62 00     # RD_S7 RS1_T0 RS2_T1 OR            ; logical or with the previous expression
 
     33 4C 7C 01     # RD_S8 RS1_S8 RS2_S7 XOR           ; shiftregister = shiftregister ^ tempword
@@ -675,7 +675,7 @@ FC 07 00 00 00 00 00 00 ## p_memsz
     ; First, calculate new shiftregister
     93 02 F0 0F     # RD_T0 !0xff ADDI
     B3 72 5C 00     # RD_T0 RS1_S8 RS2_T0 AND           ; sr_nextb = shiftregister & 0xff
-    13 5C 8C 00     # RD_S8 RS1_S8 RS2_X8 SRLI          ; shiftregister >> 8
+    1B 5C 8C 00     # RD_S8 RS1_S8 RS2_X8 SRLIW         ; shiftregister >> 8
 
     B3 C2 02 01     # RD_T0 RS1_T0 RS2_A6 XOR           ; hex(c) ^ sr_nextb
     13 93 4A 00     # RD_T1 RS1_S5 RS2_X4 SLLI          ; hold << 4

--- a/riscv64/kaem.run
+++ b/riscv64/kaem.run
@@ -70,10 +70,22 @@
 ./catm hold1.hex2 ELF-riscv64.hex2 hold.hex2
 ./hex2-0 hold1.hex2 cc_riscv64
 
-##### TESTING #######
-
-./cc_riscv64 hw.c hold.M1
-./catm hold1.M1 riscv64_defs.M1 libc-core.M1 hold.M1
-./M0 hold1.M1 hold.hex2
-./catm hold1.hex2 ELF-riscv64.hex2 hold.hex2
-./hex2-0 hold1.hex2 hw
+###########################################
+# Phase-5 Build M2-Planet from cc_riscv64 #
+###########################################
+./catm hold \
+	../M2libc/riscv64/Linux/bootstrap.c \
+	../M2-Planet/cc.h \
+	../M2libc/bootstrappable.c \
+	../M2-Planet/cc_globals.c \
+	../M2-Planet/cc_reader.c \
+	../M2-Planet/cc_strings.c \
+	../M2-Planet/cc_types.c \
+	../M2-Planet/cc_core.c \
+	../M2-Planet/cc_macro.c \
+	../M2-Planet/cc.c
+./cc_riscv64 hold M2.M1
+./catm hold riscv64_defs.M1 libc-core.M1 M2.M1
+./M0 hold temp1
+./catm hold ELF-riscv64.hex2 temp1
+./hex2-0 hold M2


### PR DESCRIPTION
Implement scratch for reading strings.
Raise max string limit to 512.

Fixes hex2 encoding bug where we rely on 32-bit arithmetic.

Build M2-Planet for RISC-V (but M2-Planet does not yet know how to generate RISCV-V assembly).