### PR TITLE
ci: Add initial workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,59 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up access and checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - run: ./bootstrap-seeds/POSIX/AMD64/kaem-optional-seed
+
+  x86:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up access and checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - run: ./bootstrap-seeds/POSIX/x86/kaem-optional-seed
+
+  aarch64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Set up access and checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - run: ./bootstrap-seeds/POSIX/AArch64/kaem-optional-seed
+
+  # There is no full bootstrap for armv7l
+
+  riscv64:
+    runs-on: ubuntu-24.04-riscv
+    steps:
+      - name: Set up access and checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - run: ./bootstrap-seeds/POSIX/riscv64/kaem-optional-seed
+
+  # riscv32 can't run on natively riscv64 and there are no riscv32 runners
+  riscv32:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install qemu and git
+        run: sudo apt-get update && sudo apt-get install qemu-user
+
+      - name: Set up access and checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - run: qemu-riscv32 ./bootstrap-seeds/POSIX/riscv32/kaem-optional-seed
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,20 @@ jobs:
         with:
           submodules: recursive
       - run: ./bootstrap-seeds/POSIX/AMD64/kaem-optional-seed
+      - name: Upload artifacts
+        if: always() # Always upload artifacts for debugging
+        uses: actions/upload-artifact@v7
+        with:
+          name: amd64-artifact
+          path: AMD64/artifact
+          if-no-files-found: error
+      - name: Upload binaries
+        if: always() # Always upload artifacts for debugging
+        uses: actions/upload-artifact@v7
+        with:
+          name: amd64-bin
+          path: AMD64/bin
+          if-no-files-found: error
 
   x86:
     runs-on: ubuntu-latest
@@ -22,6 +36,20 @@ jobs:
         with:
           submodules: recursive
       - run: ./bootstrap-seeds/POSIX/x86/kaem-optional-seed
+      - name: Upload artifacts
+        if: always() # Always upload artifacts for debugging
+        uses: actions/upload-artifact@v7
+        with:
+          name: x86-artifact
+          path: x86/artifact
+          if-no-files-found: error
+      - name: Upload binaries
+        if: always() # Always upload artifacts for debugging
+        uses: actions/upload-artifact@v7
+        with:
+          name: x86-bin
+          path: x86/bin
+          if-no-files-found: error
 
   aarch64:
     runs-on: ubuntu-24.04-arm
@@ -31,6 +59,20 @@ jobs:
         with:
           submodules: recursive
       - run: ./bootstrap-seeds/POSIX/AArch64/kaem-optional-seed
+      - name: Upload artifacts
+        if: always() # Always upload artifacts for debugging
+        uses: actions/upload-artifact@v7
+        with:
+          name: aarch64-artifact
+          path: AArch64/artifact
+          if-no-files-found: error
+      - name: Upload binaries
+        if: always() # Always upload artifacts for debugging
+        uses: actions/upload-artifact@v7
+        with:
+          name: aarch64-bin
+          path: AArch64/bin
+          if-no-files-found: error
 
   # There is no full bootstrap for armv7l
 
@@ -42,6 +84,20 @@ jobs:
         with:
           submodules: recursive
       - run: ./bootstrap-seeds/POSIX/riscv64/kaem-optional-seed
+      - name: Upload artifacts
+        if: always() # Always upload artifacts for debugging
+        uses: actions/upload-artifact@v7
+        with:
+          name: riscv64-artifact
+          path: riscv64/artifact
+          if-no-files-found: error
+      - name: Upload binaries
+        if: always() # Always upload artifacts for debugging
+        uses: actions/upload-artifact@v7
+        with:
+          name: riscv64-bin
+          path: riscv64/bin
+          if-no-files-found: error
 
   # riscv32 can't run on natively riscv64 and there are no riscv32 runners
   riscv32:
@@ -56,4 +112,18 @@ jobs:
           submodules: recursive
 
       - run: qemu-riscv32 ./bootstrap-seeds/POSIX/riscv32/kaem-optional-seed
+      - name: Upload artifacts
+        if: always() # Always upload artifacts for debugging
+        uses: actions/upload-artifact@v7
+        with:
+          name: riscv32-artifact
+          path: riscv32/artifact
+          if-no-files-found: error
+      - name: Upload binaries
+        if: always() # Always upload artifacts for debugging
+        uses: actions/upload-artifact@v7
+        with:
+          name: riscv32-bin
+          path: riscv32/bin
+          if-no-files-found: error
 


### PR DESCRIPTION
Adds an initial CI setup that just runs all the bootstraps to verify they work.

Both the `artifact` and `bin` directories are uploaded even on failure so the binaries can be inspected locally.

[A successful run](https://github.com/gtker/stage0-posix/actions/runs/28440295322)  takes around 5-10 minutes depending on how fast the RISC-V runners are.

`riscv32` can not run on `riscv64` and there are no runners for `riscv32` so we just run them through `qemu`.

The `riscv64` runner uses the runners provided by [the RISE project](https://riscv-runners.riseproject.dev/). As far as I understand it they will require @oriansj to visit [this link](https://github.com/apps/rise-risc-v-runners-personal) and approve them since this repo is hosted on his profile.

@stikonas 